### PR TITLE
Add support for webhooks

### DIFF
--- a/cmd/dish/main.go
+++ b/cmd/dish/main.go
@@ -51,7 +51,7 @@ func main() {
 	handleStateUpdate(resultsToPush)
 
 	if failedCount > 0 {
-		handleAlerts(messengerText)
+		handleAlerts(messengerText, resultsToPush)
 		log.Println(messengerText)
 		return
 	}
@@ -115,8 +115,18 @@ func handleStateUpdate(results message.Results) {
 	}
 }
 
-func handleAlerts(messengerText string) {
+func handleAlerts(messengerText string, results message.Results) {
 	if config.UseTelegram {
-		alert.SendTelegram(messengerText)
+		err := alert.SendTelegram(messengerText)
+		if err != nil {
+			log.Printf("Error sending Telegram notification: %v", err)
+		}
+	}
+
+	if config.UseWebhooks {
+		err := alert.SendWebhooks(&results)
+		if err != nil {
+			log.Printf("Error sending webhook notification: %v", err)
+		}
 	}
 }

--- a/configs/demo_sockets.json
+++ b/configs/demo_sockets.json
@@ -1,20 +1,23 @@
 {
   "items": {
-    "vxn_dev_https": { 
+    "vxn_dev_https": {
+      "id": "vxn_dev_https",
       "socket_name": "vxn-dev HTTPS",
       "host_name": "https://vxn.dev",
       "port_tcp": 443,
       "path_http": "/",
-      "expected_http_code_array": [ 200 ]
+      "expected_http_code_array": [200]
     },
     "text.n0p.cz_https": {
+      "id": "text.n0p.cz_https",
       "socket_name": "text-n0p-cz HTTPS",
       "host_name": "https://text.n0p.cz",
       "port_tcp": 443,
       "path_http": "/?",
-      "expected_http_code_array": [ 401 ]
+      "expected_http_code_array": [401]
     },
     "openttd TCP": {
+      "id": "openttd TCP",
       "socket_name": "openttd TCP",
       "host_name": "ottd.vxn.dev",
       "port_tcp": 3979,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,46 +21,29 @@ var (
 )
 
 func init() {
-	instanceName := flag.String("name", "generic-dish", "a string, dish instance name")
-	timeoutFlag := flag.Int("timeout", 10, "an int, timeout in seconds for http and tcp calls")
-	verboseFlag := flag.Bool("verbose", false, "a bool, console stdout logging toggle")
+	// system vars
+	flag.StringVar(&InstanceName, "name", "generic-dish", "a string, dish instance name")
+	flag.IntVar(&Timeout, "timeout", 10, "an int, timeout in seconds for http and tcp calls")
+	flag.BoolVar(&Verbose, "verbose", false, "a bool, console stdout logging toggle")
 
-	sourceFlag := flag.String("source", "demo_sockets.json", "a string, path to/URL JSON socket list")
-	sourceHeaderName := flag.String("hname", "", "a string, custom additional header name")
-	sourceHeaderValue := flag.String("hvalue", "", "a string, custom additional header value")
+	// source vars
+	flag.StringVar(&Source, "source", "demo_sockets.json", "a string, path to/URL JSON socket list")
+	flag.StringVar(&HeaderName, "hname", "", "a string, custom additional header name")
+	flag.StringVar(&HeaderValue, "hvalue", "", "a string, custom additional header value")
 
-	usePushgatewayFlag := flag.Bool("pushgw", false, "a bool, enable reporter module to post dish results to pushgateway")
-	targetURLFlag := flag.String("target", "", "a string, result update path/URL, plaintext/byte output")
+	// target vars
+	flag.BoolVar(&UsePushgateway, "pushgw", false, "a bool, enable reporter module to post dish results to pushgateway")
+	flag.StringVar(&TargetURL, "target", "", "a string, result update path/URL, plaintext/byte output")
 
-	// telegram provider flags
-	useTelegramFlag := flag.Bool("telegram", false, "a bool, Telegram provider usage toggle")
-	telegramBotTokenFlag := flag.String("telegramBotToken", "", "a string, Telegram bot private token")
-	telegramChatIDFlag := flag.String("telegramChatID", "", "a string/signet int, Telegram chat/channel ID")
+	// telegram vars
+	flag.BoolVar(&UseTelegram, "telegram", false, "a bool, Telegram provider usage toggle")
+	flag.StringVar(&TelegramBotToken, "telegramBotToken", "", "a string, Telegram bot private token")
+	flag.StringVar(&TelegramChatID, "telegramChatID", "", "a string/signet int, Telegram chat/channel ID")
 
-	updateStateFlag := flag.Bool("update", false, "a bool, switch for socket's last state batch upload to the source swis-api instance")
-	updateURLFlag := flag.String("updateURL", "", "a string, URL of the source swis-api instance")
+	// remote source vars
+	flag.BoolVar(&UpdateStates, "update", false, "a bool, switch for socket's last state batch upload to the source swis-api instance")
+	flag.StringVar(&UpdateURL, "updateURL", "", "a string, URL of the source swis-api instance")
 
 	flag.Parse()
 
-	// system vars
-	InstanceName = *instanceName
-	Timeout = *timeoutFlag
-	Verbose = *verboseFlag
-
-	// source vars
-	Source = *sourceFlag
-	HeaderName = *sourceHeaderName
-	HeaderValue = *sourceHeaderValue
-
-	// target vars
-	UsePushgateway = *usePushgatewayFlag
-	TargetURL = *targetURLFlag
-
-	// telegram vars
-	UseTelegram = *useTelegramFlag
-	TelegramBotToken = *telegramBotTokenFlag
-	TelegramChatID = *telegramChatIDFlag
-
-	UpdateStates = *updateStateFlag
-	UpdateURL = *updateURLFlag
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,8 @@ var (
 	Timeout          int // In seconds
 	UpdateStates     bool
 	UpdateURL        string
+	UseWebhooks      bool
+	WebhookURL       string
 )
 
 func init() {
@@ -27,7 +29,7 @@ func init() {
 	flag.BoolVar(&Verbose, "verbose", false, "a bool, console stdout logging toggle")
 
 	// source vars
-	flag.StringVar(&Source, "source", "demo_sockets.json", "a string, path to/URL JSON socket list")
+	flag.StringVar(&Source, "source", "./configs/demo_sockets.json", "a string, path to/URL JSON socket list")
 	flag.StringVar(&HeaderName, "hname", "", "a string, custom additional header name")
 	flag.StringVar(&HeaderValue, "hvalue", "", "a string, custom additional header value")
 
@@ -43,6 +45,10 @@ func init() {
 	// remote source vars
 	flag.BoolVar(&UpdateStates, "update", false, "a bool, switch for socket's last state batch upload to the source swis-api instance")
 	flag.StringVar(&UpdateURL, "updateURL", "", "a string, URL of the source swis-api instance")
+
+	// webhook vars
+	flag.BoolVar(&UseWebhooks, "webhooks", false, "a bool, Webhook usage toggle")
+	flag.StringVar(&WebhookURL, "webhookURL", "", "a string, URL of webhook endpoint")
 
 	flag.Parse()
 


### PR DESCRIPTION
Add support for webhooks using the `webhooks` and `webhookURL` flags. 

Logs the prepared data & the received response status + body in verbose mode.