### PR TITLE
Add socket tests and fix error handling

### DIFF
--- a/pkg/socket/fetch.go
+++ b/pkg/socket/fetch.go
@@ -1,8 +1,8 @@
 package socket
 
 import (
+	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"regexp"
@@ -38,12 +38,10 @@ func fetchRemoteStream(url string, apiHeaderName string, apiHeaderValue string) 
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		log.Fatalf("error fetching sockets from remote source --- got %d (%s)", resp.StatusCode, resp.Status)
+		return nil, fmt.Errorf("error fetching sockets from remote source --- got %d (%s)", resp.StatusCode, resp.Status)
 	}
 
-	body := resp.Body
-
-	return body, nil
+	return resp.Body, nil
 }
 
 // fetchFileStream opens a file and returns [io.ReadCloser] for reading from and closing the stream.

--- a/pkg/socket/fetch_test.go
+++ b/pkg/socket/fetch_test.go
@@ -1,0 +1,195 @@
+package socket
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// CreateTempFile is a helper function to create a temp file with content
+func CreateTempFile(t *testing.T, content string) string {
+	t.Helper()
+
+	file, err := os.CreateTemp("", "test_sockets_*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer file.Close()
+
+	if _, err := file.Write([]byte(content)); err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+
+	return file.Name()
+}
+
+func TestFetchRemoteStream(t *testing.T) {
+	expectedHeaderName := "Authorization"
+	expectedHeaderValue := "Bearer [JWT TOKEN]"
+
+	// simulate valid response
+	testServerValid := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaderValue := r.Header.Get(expectedHeaderName)
+		if gotHeaderValue != expectedHeaderValue {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer testServerValid.Close()
+
+	// simulate invalid response
+	testServerInvalid := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+	}))
+	defer testServerValid.Close()
+
+	tests := []struct {
+		name        string
+		url         string
+		headerName  string
+		headerValue string
+		wantErr     bool
+	}{
+		{
+			name:        "successful request",
+			url:         testServerValid.URL,
+			headerName:  "Authorization",
+			headerValue: "Bearer [JWT TOKEN]",
+			wantErr:     false,
+		},
+		{
+			name:        "missing auth header",
+			url:         testServerValid.URL,
+			headerName:  "",
+			headerValue: "",
+			wantErr:     true,
+		},
+		{
+			name:        "invalid request",
+			url:         testServerInvalid.URL,
+			headerName:  "",
+			headerValue: "",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := fetchRemoteStream(tt.url, tt.headerName, tt.headerValue)
+
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected an error but got none")
+			} else if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestFetchFileStream(t *testing.T) {
+	testContent := "testcontent"
+	testFile := CreateTempFile(t, testContent)
+	defer os.Remove(testFile)
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{
+			name:    "valid file path",
+			path:    testFile,
+			wantErr: false,
+		},
+		{
+			name:    "invalid file path",
+			path:    "non_existent.json",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader, err := fetchFileStream(tt.path)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			defer reader.Close()
+			body, _ := io.ReadAll(reader)
+			if string(body) != testContent {
+				t.Fatalf("expected %s but got %s", testContent, body)
+			}
+		})
+	}
+}
+
+func TestGetStreamFromPath(t *testing.T) {
+	// this tests only valid sources
+	testContent := "testdata"
+	testFile := CreateTempFile(t, testContent)
+	defer os.Remove(testFile)
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(testContent))
+	}))
+	defer testServer.Close()
+
+	tests := []struct {
+		name        string
+		input       string
+		headerName  string
+		headerValue string
+		expected    string
+		wantErr     bool
+	}{
+		{
+			name:     "path is filepath",
+			input:    testFile,
+			expected: testContent,
+			wantErr:  false,
+		},
+		{
+			name:     "path is url",
+			input:    testServer.URL,
+			expected: testContent,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader, err := getStreamFromPath(tt.input, tt.headerName, tt.headerValue)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			defer reader.Close()
+			body, _ := io.ReadAll(reader)
+			if string(body) != tt.expected {
+				t.Fatalf("expected %s but got %s", tt.expected, body)
+			}
+		})
+	}
+}

--- a/pkg/socket/fetch_test.go
+++ b/pkg/socket/fetch_test.go
@@ -29,7 +29,7 @@ func TestFetchRemoteStream(t *testing.T) {
 	expectedHeaderName := "Authorization"
 	expectedHeaderValue := "Bearer [JWT TOKEN]"
 
-	// simulate valid response
+	// Simulate valid response
 	testServerValid := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotHeaderValue := r.Header.Get(expectedHeaderName)
 		if gotHeaderValue != expectedHeaderValue {
@@ -41,7 +41,7 @@ func TestFetchRemoteStream(t *testing.T) {
 	}))
 	defer testServerValid.Close()
 
-	// simulate invalid response
+	// Simulate invalid response
 	testServerInvalid := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 	}))
@@ -55,21 +55,21 @@ func TestFetchRemoteStream(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			name:        "successful request",
+			name:        "Successful Request",
 			url:         testServerValid.URL,
 			headerName:  "Authorization",
 			headerValue: "Bearer [JWT TOKEN]",
 			wantErr:     false,
 		},
 		{
-			name:        "missing auth header",
+			name:        "Missing Auth Header",
 			url:         testServerValid.URL,
 			headerName:  "",
 			headerValue: "",
 			wantErr:     true,
 		},
 		{
-			name:        "invalid request",
+			name:        "Invalid Request",
 			url:         testServerInvalid.URL,
 			headerName:  "",
 			headerValue: "",
@@ -82,9 +82,9 @@ func TestFetchRemoteStream(t *testing.T) {
 			_, err := fetchRemoteStream(tt.url, tt.headerName, tt.headerValue)
 
 			if tt.wantErr && err == nil {
-				t.Fatalf("expected an error but got none")
+				t.Error("expected an error but got none")
 			} else if !tt.wantErr && err != nil {
-				t.Fatalf("unexpected error: %v", err)
+				t.Errorf("unexpected error: %v", err)
 			}
 		})
 	}
@@ -101,12 +101,12 @@ func TestFetchFileStream(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "valid file path",
+			name:    "Valid File Path",
 			path:    testFile,
 			wantErr: false,
 		},
 		{
-			name:    "invalid file path",
+			name:    "Invalid File Path",
 			path:    "non_existent.json",
 			wantErr: true,
 		},
@@ -118,7 +118,7 @@ func TestFetchFileStream(t *testing.T) {
 
 			if tt.wantErr {
 				if err == nil {
-					t.Fatalf("expected an error but got none")
+					t.Error("expected an error but got none")
 				}
 				return
 			}
@@ -130,14 +130,14 @@ func TestFetchFileStream(t *testing.T) {
 			defer reader.Close()
 			body, _ := io.ReadAll(reader)
 			if string(body) != testContent {
-				t.Fatalf("expected %s but got %s", testContent, body)
+				t.Errorf("expected %s but got %s", testContent, body)
 			}
 		})
 	}
 }
 
 func TestGetStreamFromPath(t *testing.T) {
-	// this tests only valid sources
+	// This tests only valid sources
 	testContent := "testdata"
 	testFile := CreateTempFile(t, testContent)
 	defer os.Remove(testFile)
@@ -157,13 +157,13 @@ func TestGetStreamFromPath(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			name:     "path is filepath",
+			name:     "Path is Filepath",
 			input:    testFile,
 			expected: testContent,
 			wantErr:  false,
 		},
 		{
-			name:     "path is url",
+			name:     "Path is URL",
 			input:    testServer.URL,
 			expected: testContent,
 			wantErr:  false,
@@ -176,7 +176,7 @@ func TestGetStreamFromPath(t *testing.T) {
 
 			if tt.wantErr {
 				if err == nil {
-					t.Fatalf("expected an error but got none")
+					t.Error("expected an error but got none")
 				}
 				return
 			}
@@ -188,7 +188,7 @@ func TestGetStreamFromPath(t *testing.T) {
 			defer reader.Close()
 			body, _ := io.ReadAll(reader)
 			if string(body) != tt.expected {
-				t.Fatalf("expected %s but got %s", tt.expected, body)
+				t.Errorf("expected %s but got %s", tt.expected, body)
 			}
 		})
 	}

--- a/pkg/socket/socket_test.go
+++ b/pkg/socket/socket_test.go
@@ -1,0 +1,89 @@
+package socket
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestFetchSocketList(t *testing.T) {
+	validJSON := `{
+		"sockets": [
+			{
+				"id": "vxn_dev_https",
+				"socket_name": "vxn-dev HTTPS",
+				"host_name": "https://vxn.dev",
+				"port_tcp": 443,
+				"path_http": "/",
+				"expected_http_code_array": [200]
+			}
+		]
+	}`
+	invalidJSON := `{"sockets": [ { "id": "invalid"`
+
+	validFile := CreateTempFile(t, validJSON)
+	defer os.Remove(validFile)
+
+	invalidFile := CreateTempFile(t, invalidJSON)
+	defer os.Remove(invalidFile)
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(validJSON))
+	}))
+	defer testServer.Close()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		expectLen int
+	}{
+		{
+			"Valid File",
+			validFile,
+			false,
+			1,
+		},
+		{
+			"Valid URL",
+			testServer.URL,
+			false,
+			1,
+		},
+		{
+			"Invalid File Path",
+			"non_existent.json",
+			true,
+			0,
+		},
+		{
+			"Malformed JSON",
+			invalidFile,
+			true,
+			0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list, err := FetchSocketList(tt.input, "", "", false)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(list.Sockets) != tt.expectLen {
+				t.Fatalf("expected %d sockets, got %d", tt.expectLen, len(list.Sockets))
+			}
+		})
+	}
+}

--- a/pkg/socket/socket_test.go
+++ b/pkg/socket/socket_test.go
@@ -72,17 +72,17 @@ func TestFetchSocketList(t *testing.T) {
 
 			if tt.wantErr {
 				if err == nil {
-					t.Fatalf("expected error but got none")
+					t.Error("expected error but got none")
 				}
 				return
 			}
 
 			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+				t.Errorf("unexpected error: %v", err)
 			}
 
 			if len(list.Sockets) != tt.expectLen {
-				t.Fatalf("expected %d sockets, got %d", tt.expectLen, len(list.Sockets))
+				t.Errorf("expected %d sockets, got %d", tt.expectLen, len(list.Sockets))
 			}
 		})
 	}


### PR DESCRIPTION
Hi,

This PR adds socket tests addressing this task [Add tests #14](https://github.com/thevxn/dish/issues/14).  

### Changes  
Also, I have fixed `fetchRemoteStream` where instead of returning an error, there was `log.Fatalf`.