### PR TITLE
refactor: Use Config struct instead of separate parameters

### DIFF
--- a/cmd/dish/runner.go
+++ b/cmd/dish/runner.go
@@ -46,7 +46,7 @@ func fanInChannels(channels ...chan socket.Result) <-chan socket.Result {
 // runTests orchestrates the process of checking of a list of sockets. It fetches the socket list, runs socket checks, collects results and returns them.
 func runTests(cfg *config.Config) (*testResults, error) {
 	// Load socket list to run tests on
-	list, err := socket.FetchSocketList(cfg.Source, cfg.ApiCacheSockets, cfg.ApiCacheDirectory, cfg.ApiCacheTTLMinutes, cfg.ApiHeaderName, cfg.ApiHeaderValue)
+	list, err := socket.FetchSocketList(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("error loading socket list: %w", err)
 	}

--- a/pkg/alert/api.go
+++ b/pkg/alert/api.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+
+	"go.vxn.dev/dish/pkg/config"
 )
 
 type apiSender struct {
@@ -17,8 +19,8 @@ type apiSender struct {
 	notifySuccess bool
 }
 
-func NewAPISender(httpClient HTTPClient, url string, headerName string, headerValue string, verbose bool, notifySuccess bool) (*apiSender, error) {
-	parsedURL, err := parseAndValidateURL(url, nil)
+func NewAPISender(httpClient HTTPClient, config *config.Config) (*apiSender, error) {
+	parsedURL, err := parseAndValidateURL(config.ApiURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -26,10 +28,10 @@ func NewAPISender(httpClient HTTPClient, url string, headerName string, headerVa
 	return &apiSender{
 		httpClient:    httpClient,
 		url:           parsedURL.String(),
-		headerName:    headerName,
-		headerValue:   headerValue,
-		verbose:       verbose,
-		notifySuccess: notifySuccess,
+		headerName:    config.ApiHeaderName,
+		headerValue:   config.ApiHeaderValue,
+		verbose:       config.Verbose,
+		notifySuccess: config.MachineNotifySuccess,
 	}, nil
 }
 

--- a/pkg/alert/api_test.go
+++ b/pkg/alert/api_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"go.vxn.dev/dish/pkg/config"
 	"go.vxn.dev/dish/pkg/testhelpers"
 )
 
@@ -25,7 +26,15 @@ func TestNewAPISender(t *testing.T) {
 		verbose:       verbose,
 	}
 
-	actual, _ := NewAPISender(mockHTTPClient, url, headerName, headerValue, verbose, notifySuccess)
+	cfg := &config.Config{
+		ApiURL:               url,
+		ApiHeaderName:        headerName,
+		ApiHeaderValue:       headerValue,
+		MachineNotifySuccess: notifySuccess,
+		Verbose:              verbose,
+	}
+
+	actual, _ := NewAPISender(mockHTTPClient, cfg)
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Fatalf("expected %v, got %v", expected, actual)
@@ -52,6 +61,16 @@ func TestSend_API(t *testing.T) {
 			"test1": true,
 			"test2": false,
 		},
+	}
+
+	newConfig := func(headerName, headerValue string, notifySuccess, verbose bool) *config.Config {
+		return &config.Config{
+			ApiURL:               url,
+			MachineNotifySuccess: notifySuccess,
+			Verbose:              verbose,
+			ApiHeaderName:        headerName,
+			ApiHeaderValue:       headerValue,
+		}
 	}
 
 	tests := []struct {
@@ -190,7 +209,8 @@ func TestSend_API(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sender, err := NewAPISender(tt.client, url, tt.headerName, tt.headerValue, tt.verbose, tt.notifySuccess)
+			cfg := newConfig(tt.headerName, tt.headerValue, tt.notifySuccess, tt.verbose)
+			sender, err := NewAPISender(tt.client, cfg)
 			if err != nil {
 				t.Fatalf("failed to create API sender instance: %v", err)
 			}

--- a/pkg/alert/notifier.go
+++ b/pkg/alert/notifier.go
@@ -39,7 +39,7 @@ func NewNotifier(httpClient HTTPClient, config *config.Config) *notifier {
 
 	// Telegram
 	if config.TelegramBotToken != "" && config.TelegramChatID != "" {
-		notificationSenders = append(notificationSenders, NewTelegramSender(httpClient, config.TelegramChatID, config.TelegramBotToken, config.Verbose, config.TextNotifySuccess))
+		notificationSenders = append(notificationSenders, NewTelegramSender(httpClient, config))
 	}
 
 	// Set machine interface integrations to be notified (e.g. Webhooks)
@@ -47,7 +47,7 @@ func NewNotifier(httpClient HTTPClient, config *config.Config) *notifier {
 
 	// Remote API
 	if config.ApiURL != "" {
-		apiSender, err := NewAPISender(httpClient, config.ApiURL, config.ApiHeaderName, config.ApiHeaderValue, config.Verbose, config.MachineNotifySuccess)
+		apiSender, err := NewAPISender(httpClient, config)
 		if err != nil {
 			log.Println("error creating new remote API sender:", err)
 		} else {
@@ -57,7 +57,7 @@ func NewNotifier(httpClient HTTPClient, config *config.Config) *notifier {
 
 	// Webhooks
 	if config.WebhookURL != "" {
-		webhookSender, err := NewWebhookSender(httpClient, config.WebhookURL, config.Verbose, config.MachineNotifySuccess)
+		webhookSender, err := NewWebhookSender(httpClient, config)
 		if err != nil {
 			log.Println("error creating new webhook sender:", err)
 		} else {
@@ -67,7 +67,7 @@ func NewNotifier(httpClient HTTPClient, config *config.Config) *notifier {
 
 	// Pushgateway
 	if config.PushgatewayURL != "" {
-		pgwSender, err := NewPushgatewaySender(httpClient, config.PushgatewayURL, config.InstanceName, config.Verbose, config.MachineNotifySuccess)
+		pgwSender, err := NewPushgatewaySender(httpClient, config)
 		if err != nil {
 			log.Println("error creating new Pushgateway sender:", err)
 		} else {

--- a/pkg/alert/pushgateway.go
+++ b/pkg/alert/pushgateway.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"net/http"
 	"text/template"
+
+	"go.vxn.dev/dish/pkg/config"
 )
 
 const (
@@ -36,9 +38,9 @@ type pushgatewaySender struct {
 }
 
 // NewPushgatewaySender validates the provided URL, prepares and parses a message template to be used for alerting and returns a new pushgatewaySender struct with the provided attributes.
-func NewPushgatewaySender(httpClient HTTPClient, url string, instanceName string, verbose bool, notifySuccess bool) (*pushgatewaySender, error) {
+func NewPushgatewaySender(httpClient HTTPClient, config *config.Config) (*pushgatewaySender, error) {
 	// Parse and validate the provided URL
-	parsedURL, err := parseAndValidateURL(url, nil)
+	parsedURL, err := parseAndValidateURL(config.PushgatewayURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -52,9 +54,9 @@ func NewPushgatewaySender(httpClient HTTPClient, url string, instanceName string
 	return &pushgatewaySender{
 		httpClient:    httpClient,
 		url:           parsedURL.String(),
-		instanceName:  instanceName,
-		verbose:       verbose,
-		notifySuccess: notifySuccess,
+		instanceName:  config.InstanceName,
+		verbose:       config.Verbose,
+		notifySuccess: config.MachineNotifySuccess,
 		tmpl:          tmpl,
 	}, nil
 }

--- a/pkg/alert/pushgateway_test.go
+++ b/pkg/alert/pushgateway_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"go.vxn.dev/dish/pkg/config"
 	"go.vxn.dev/dish/pkg/testhelpers"
 )
 
@@ -24,7 +25,14 @@ func TestNewPushgatewaySender(t *testing.T) {
 		// template will be compared based on its output, no need for it here
 	}
 
-	actual, err := NewPushgatewaySender(mockHTTPClient, url, instanceName, verbose, notifySuccess)
+	cfg := &config.Config{
+		PushgatewayURL:       url,
+		InstanceName:         instanceName,
+		Verbose:              verbose,
+		MachineNotifySuccess: notifySuccess,
+	}
+
+	actual, err := NewPushgatewaySender(mockHTTPClient, cfg)
 	if err != nil {
 		t.Fatalf("error creating a new Pushgateway sender instance: %v", err)
 	}
@@ -66,6 +74,15 @@ func TestSend_Pushgateway(t *testing.T) {
 			"test1": true,
 			"test2": false,
 		},
+	}
+
+	newConfig := func(url, instanceName string, notifySuccess, verbose bool) *config.Config {
+		return &config.Config{
+			PushgatewayURL:       url,
+			InstanceName:         instanceName,
+			Verbose:              verbose,
+			MachineNotifySuccess: notifySuccess,
+		}
 	}
 
 	tests := []struct {
@@ -192,7 +209,8 @@ func TestSend_Pushgateway(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sender, err := NewPushgatewaySender(tt.client, url, tt.instanceName, tt.verbose, tt.notifySuccess)
+			cfg := newConfig(url, tt.instanceName, tt.notifySuccess, tt.verbose)
+			sender, err := NewPushgatewaySender(tt.client, cfg)
 			if err != nil {
 				t.Fatalf("failed to create Pushgateway sender instance: %v", err)
 			}
@@ -206,7 +224,14 @@ func TestSend_Pushgateway(t *testing.T) {
 }
 
 func TestCreateMessage(t *testing.T) {
-	sender, err := NewPushgatewaySender(&testhelpers.SuccessStatusHTTPClient{}, "https://abc123.xyz.com", "test-instance", false, false)
+	cfg := &config.Config{
+		PushgatewayURL:       "https://abc123.xyz.com",
+		InstanceName:         "test-instance",
+		MachineNotifySuccess: false,
+		Verbose:              false,
+	}
+
+	sender, err := NewPushgatewaySender(&testhelpers.SuccessStatusHTTPClient{}, cfg)
 	if err != nil {
 		t.Fatalf("failed to create Pushgateway sender instance: %v", err)
 	}

--- a/pkg/alert/telegram.go
+++ b/pkg/alert/telegram.go
@@ -5,10 +5,14 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+
+	"go.vxn.dev/dish/pkg/config"
 )
 
-const baseURL = "https://api.telegram.org"
-const messageTitle = "\U0001F4E1 <b>dish run results</b>:" // 📡
+const (
+	baseURL      = "https://api.telegram.org"
+	messageTitle = "\U0001F4E1 <b>dish run results</b>:" // 📡
+)
 
 type telegramSender struct {
 	httpClient    HTTPClient
@@ -18,13 +22,13 @@ type telegramSender struct {
 	notifySuccess bool
 }
 
-func NewTelegramSender(httpClient HTTPClient, chatID string, token string, verbose bool, notifySuccess bool) *telegramSender {
+func NewTelegramSender(httpClient HTTPClient, config *config.Config) *telegramSender {
 	return &telegramSender{
 		httpClient,
-		chatID,
-		token,
-		verbose,
-		notifySuccess,
+		config.TelegramChatID,
+		config.TelegramBotToken,
+		config.Verbose,
+		config.TextNotifySuccess,
 	}
 }
 

--- a/pkg/alert/telegram_test.go
+++ b/pkg/alert/telegram_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"go.vxn.dev/dish/pkg/config"
 	"go.vxn.dev/dish/pkg/testhelpers"
 )
 
@@ -23,7 +24,14 @@ func TestNewTelegramSender(t *testing.T) {
 		notifySuccess: notifySuccess,
 	}
 
-	actual := NewTelegramSender(mockHTTPClient, chatID, token, verbose, notifySuccess)
+	cfg := &config.Config{
+		TelegramChatID:    chatID,
+		TelegramBotToken:  token,
+		Verbose:           verbose,
+		TextNotifySuccess: notifySuccess,
+	}
+
+	actual := NewTelegramSender(mockHTTPClient, cfg)
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Fatalf("expected %v, got %v", expected, actual)
@@ -31,6 +39,15 @@ func TestNewTelegramSender(t *testing.T) {
 }
 
 func TestSend_Telegram(t *testing.T) {
+	newConfig := func(chatID, token string, verbose, notifySuccess bool) *config.Config {
+		return &config.Config{
+			TelegramChatID:    chatID,
+			TelegramBotToken:  token,
+			Verbose:           verbose,
+			TextNotifySuccess: notifySuccess,
+		}
+	}
+
 	tests := []struct {
 		name          string
 		client        HTTPClient
@@ -116,7 +133,8 @@ func TestSend_Telegram(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sender := NewTelegramSender(tt.client, "-123", "abc123", tt.verbose, tt.notifySuccess)
+			cfg := newConfig("-123", "abc123", tt.verbose, tt.notifySuccess)
+			sender := NewTelegramSender(tt.client, cfg)
 
 			err := sender.send(tt.rawMessage, tt.failedCount)
 

--- a/pkg/alert/url.go
+++ b/pkg/alert/url.go
@@ -10,7 +10,7 @@ import (
 var defaultSchemes = []string{"http", "https"}
 
 // parseAndValidateURL parses and validates a URL with strict scheme requirements.
-// The supportedSchemes parameter allows customizing allowed protocols (defaults to http/https if nil).
+// The supportedSchemes parameter allows customizing allowed protocols (defaults to HTTP/HTTPS if nil).
 func parseAndValidateURL(rawURL string, supportedSchemes []string) (*url.URL, error) {
 	if strings.TrimSpace(rawURL) == "" {
 		return nil, fmt.Errorf("URL cannot be empty")

--- a/pkg/alert/webhook.go
+++ b/pkg/alert/webhook.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+
+	"go.vxn.dev/dish/pkg/config"
 )
 
 type webhookSender struct {
@@ -15,8 +17,8 @@ type webhookSender struct {
 	notifySuccess bool
 }
 
-func NewWebhookSender(httpClient HTTPClient, url string, verbose bool, notifySuccess bool) (*webhookSender, error) {
-	parsedURL, err := parseAndValidateURL(url, nil)
+func NewWebhookSender(httpClient HTTPClient, config *config.Config) (*webhookSender, error) {
+	parsedURL, err := parseAndValidateURL(config.WebhookURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -24,8 +26,8 @@ func NewWebhookSender(httpClient HTTPClient, url string, verbose bool, notifySuc
 	return &webhookSender{
 		httpClient:    httpClient,
 		url:           parsedURL.String(),
-		verbose:       verbose,
-		notifySuccess: notifySuccess,
+		verbose:       config.Verbose,
+		notifySuccess: config.MachineNotifySuccess,
 	}, nil
 }
 

--- a/pkg/alert/webhook_test.go
+++ b/pkg/alert/webhook_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"go.vxn.dev/dish/pkg/config"
 	"go.vxn.dev/dish/pkg/testhelpers"
 )
 
@@ -21,7 +22,12 @@ func TestNewWebhookSender(t *testing.T) {
 		verbose:       verbose,
 	}
 
-	actual, _ := NewWebhookSender(mockHTTPClient, url, verbose, notifySuccess)
+	cfg := &config.Config{
+		WebhookURL:           url,
+		Verbose:              verbose,
+		MachineNotifySuccess: notifySuccess,
+	}
+	actual, _ := NewWebhookSender(mockHTTPClient, cfg)
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Fatalf("expected %v, got %v", expected, actual)
@@ -46,6 +52,14 @@ func TestSend_Webhook(t *testing.T) {
 			"test1": true,
 			"test2": false,
 		},
+	}
+
+	newConfig := func(url string, notifySuccess, verbose bool) *config.Config {
+		return &config.Config{
+			WebhookURL:           url,
+			Verbose:              verbose,
+			MachineNotifySuccess: notifySuccess,
+		}
 	}
 
 	tests := []struct {
@@ -151,7 +165,8 @@ func TestSend_Webhook(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sender, err := NewWebhookSender(tt.client, url, tt.verbose, tt.notifySuccess)
+			cfg := newConfig(url, tt.verbose, tt.notifySuccess)
+			sender, err := NewWebhookSender(tt.client, cfg)
 			if err != nil {
 				t.Fatalf("failed to create Webhook sender instance: %v", err)
 			}

--- a/pkg/socket/fetch_local.go
+++ b/pkg/socket/fetch_local.go
@@ -15,9 +15,9 @@ func fetchSocketsFromFile(config *config.Config) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	// TODO: replace with logger
+	// TODO: Replace with logger
 	if config.Verbose {
-		log.Printf("Fetching sockets from the source (%s)", config.Source)
+		log.Printf("fetching sockets from file (%s)", config.Source)
 	}
 
 	return file, nil

--- a/pkg/socket/fetch_local.go
+++ b/pkg/socket/fetch_local.go
@@ -2,10 +2,23 @@ package socket
 
 import (
 	"io"
+	"log"
 	"os"
+
+	"go.vxn.dev/dish/pkg/config"
 )
 
 // fetchSocketsFromFile opens a file and returns [io.ReadCloser] for reading from the stream.
-func fetchSocketsFromFile(input string) (io.ReadCloser, error) {
-	return os.Open(input)
+func fetchSocketsFromFile(cfg *config.Config) (io.ReadCloser, error) {
+	file, err := os.Open(cfg.Source)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: replace with logger
+	if cfg.Verbose {
+		log.Printf("Fetching sockets from the source (%s)", cfg.Source)
+	}
+
+	return file, nil
 }

--- a/pkg/socket/fetch_local.go
+++ b/pkg/socket/fetch_local.go
@@ -9,15 +9,15 @@ import (
 )
 
 // fetchSocketsFromFile opens a file and returns [io.ReadCloser] for reading from the stream.
-func fetchSocketsFromFile(cfg *config.Config) (io.ReadCloser, error) {
-	file, err := os.Open(cfg.Source)
+func fetchSocketsFromFile(config *config.Config) (io.ReadCloser, error) {
+	file, err := os.Open(config.Source)
 	if err != nil {
 		return nil, err
 	}
 
 	// TODO: replace with logger
-	if cfg.Verbose {
-		log.Printf("Fetching sockets from the source (%s)", cfg.Source)
+	if config.Verbose {
+		log.Printf("Fetching sockets from the source (%s)", config.Source)
 	}
 
 	return file, nil

--- a/pkg/socket/fetch_local_test.go
+++ b/pkg/socket/fetch_local_test.go
@@ -4,13 +4,17 @@ import (
 	"io"
 	"testing"
 
+	"go.vxn.dev/dish/pkg/config"
 	"go.vxn.dev/dish/pkg/testhelpers"
 )
 
 func TestFetchSocketsFromFile(t *testing.T) {
 	filePath := testhelpers.TestFile(t, "randomhash.json", []byte(testhelpers.TestSocketList))
+	cfg := &config.Config{
+		Source: filePath,
+	}
 
-	reader, err := fetchSocketsFromFile(filePath)
+	reader, err := fetchSocketsFromFile(cfg)
 	if err != nil {
 		t.Fatalf("Failed to fetch sockets from file %v\n", err)
 	}

--- a/pkg/socket/fetch_remote.go
+++ b/pkg/socket/fetch_remote.go
@@ -31,24 +31,24 @@ func copyBody(body io.ReadCloser, buf *bytes.Buffer) error {
 //   - Optional query parameters
 //
 // Example url: http://api.example.com:5569/stream?query=variable
-func fetchSocketsFromRemote(cfg *config.Config) (io.ReadCloser, error) {
-	cacheFilePath := hashUrlToFilePath(cfg.Source, cfg.ApiCacheDirectory)
+func fetchSocketsFromRemote(config *config.Config) (io.ReadCloser, error) {
+	cacheFilePath := hashUrlToFilePath(config.Source, config.ApiCacheDirectory)
 
 	// If we do not want to cache sockets to the file, fetch from network
-	if !cfg.ApiCacheSockets {
-		return loadFreshSockets(cfg.Source, cfg.ApiHeaderName, cfg.ApiHeaderValue)
+	if !config.ApiCacheSockets {
+		return loadFreshSockets(config.Source, config.ApiHeaderName, config.ApiHeaderValue)
 	}
 
 	// If cache is enabled, try to load sockets from it first
-	cachedReader, cacheTime, err := loadCachedSockets(cacheFilePath, cfg.ApiCacheTTLMinutes)
+	cachedReader, cacheTime, err := loadCachedSockets(cacheFilePath, config.ApiCacheTTLMinutes)
 	// If cache is expired or fails to load, attempt to fetch fresh sockets
 	if err != nil {
-		log.Printf("cache unavailable for URL: %s (reason: %v); attempting network fetch", cfg.Source, err)
+		log.Printf("cache unavailable for URL: %s (reason: %v); attempting network fetch", config.Source, err)
 
 		// Fetch fresh sockets from network
-		respBody, fetchErr := loadFreshSockets(cfg.Source, cfg.ApiHeaderName, cfg.ApiHeaderValue)
+		respBody, fetchErr := loadFreshSockets(config.Source, config.ApiHeaderName, config.ApiHeaderValue)
 		if fetchErr != nil {
-			log.Printf("fetching socket list from remote API at %s failed: %v", cfg.Source, fetchErr)
+			log.Printf("fetching socket list from remote API at %s failed: %v", config.Source, fetchErr)
 
 			// If the fetch fails and expired cache is not available, return the fetch error
 			if err != ErrExpiredCache {
@@ -65,7 +65,7 @@ func fetchSocketsFromRemote(cfg *config.Config) (io.ReadCloser, error) {
 			return nil, fmt.Errorf("failed to copy response body: %w", err)
 		}
 
-		if err := saveSocketsToCache(cacheFilePath, cfg.ApiCacheDirectory, buf.Bytes()); err != nil {
+		if err := saveSocketsToCache(cacheFilePath, config.ApiCacheDirectory, buf.Bytes()); err != nil {
 			log.Printf("failed to save fetched sockets to cache: %v", err)
 		}
 

--- a/pkg/socket/fetch_remote.go
+++ b/pkg/socket/fetch_remote.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"net/http"
 	"time"
+
+	"go.vxn.dev/dish/pkg/config"
 )
 
 // copyBody copies the provided response body to the provided buffer. The body is closed.
@@ -29,25 +31,24 @@ func copyBody(body io.ReadCloser, buf *bytes.Buffer) error {
 //   - Optional query parameters
 //
 // Example url: http://api.example.com:5569/stream?query=variable
-func fetchSocketsFromRemote(url string, cacheSockets bool, cacheDir string, cacheTTL uint, apiHeaderName string, apiHeaderValue string) (io.ReadCloser, error) {
-	cacheFilePath := hashUrlToFilePath(url, cacheDir)
+func fetchSocketsFromRemote(cfg *config.Config) (io.ReadCloser, error) {
+	cacheFilePath := hashUrlToFilePath(cfg.Source, cfg.ApiCacheDirectory)
 
 	// If we do not want to cache sockets to the file, fetch from network
-	if !cacheSockets {
-		return loadFreshSockets(url, apiHeaderName, apiHeaderValue)
+	if !cfg.ApiCacheSockets {
+		return loadFreshSockets(cfg.Source, cfg.ApiHeaderName, cfg.ApiHeaderValue)
 	}
 
 	// If cache is enabled, try to load sockets from it first
-	cachedReader, cacheTime, err := loadCachedSockets(cacheFilePath, cacheTTL)
-
+	cachedReader, cacheTime, err := loadCachedSockets(cacheFilePath, cfg.ApiCacheTTLMinutes)
 	// If cache is expired or fails to load, attempt to fetch fresh sockets
 	if err != nil {
-		log.Printf("cache unavailable for URL: %s (reason: %v); attempting network fetch", url, err)
+		log.Printf("cache unavailable for URL: %s (reason: %v); attempting network fetch", cfg.Source, err)
 
 		// Fetch fresh sockets from network
-		respBody, fetchErr := loadFreshSockets(url, apiHeaderName, apiHeaderValue)
+		respBody, fetchErr := loadFreshSockets(cfg.Source, cfg.ApiHeaderName, cfg.ApiHeaderValue)
 		if fetchErr != nil {
-			log.Printf("fetching socket list from remote API at %s failed: %v", url, fetchErr)
+			log.Printf("fetching socket list from remote API at %s failed: %v", cfg.Source, fetchErr)
 
 			// If the fetch fails and expired cache is not available, return the fetch error
 			if err != ErrExpiredCache {
@@ -64,7 +65,7 @@ func fetchSocketsFromRemote(url string, cacheSockets bool, cacheDir string, cach
 			return nil, fmt.Errorf("failed to copy response body: %w", err)
 		}
 
-		if err := saveSocketsToCache(cacheFilePath, cacheDir, buf.Bytes()); err != nil {
+		if err := saveSocketsToCache(cacheFilePath, cfg.ApiCacheDirectory, buf.Bytes()); err != nil {
 			log.Printf("failed to save fetched sockets to cache: %v", err)
 		}
 

--- a/pkg/socket/fetch_remote_test.go
+++ b/pkg/socket/fetch_remote_test.go
@@ -7,90 +7,63 @@ import (
 	"path/filepath"
 	"testing"
 
+	"go.vxn.dev/dish/pkg/config"
 	"go.vxn.dev/dish/pkg/testhelpers"
 )
 
 func TestFetchSocketsFromRemote(t *testing.T) {
 	apiHeaderName := "Authorization"
 	apiHeaderValue := "Bearer xyzzzzzzz"
-
 	mockServer := testhelpers.NewMockServer(t, apiHeaderName, apiHeaderValue, testhelpers.TestSocketList, http.StatusOK)
 
-	t.Run("Fetch With Valid Cache", func(t *testing.T) {
-		filePath := testhelpers.TestFile(t, "randomhash.json", []byte(testhelpers.TestSocketList))
-		cacheDir := filepath.Dir(filePath)
+	filePath := testhelpers.TestFile(t, "randomhash.json", []byte(testhelpers.TestSocketList))
+	cacheDir := filepath.Dir(filePath)
 
-		resp, err := fetchSocketsFromRemote(mockServer.URL, true, cacheDir, 10, apiHeaderName, apiHeaderValue)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
+	newCfg := func(source string, useCache bool, ttl uint) *config.Config {
+		return &config.Config{
+			Source:             source,
+			ApiCacheSockets:    useCache,
+			ApiCacheDirectory:  cacheDir,
+			ApiCacheTTLMinutes: ttl,
+			ApiHeaderName:      apiHeaderName,
+			ApiHeaderValue:     apiHeaderValue,
 		}
+	}
 
-		readBytes, err := io.ReadAll(resp)
-		if err != nil {
-			t.Fatalf("failed to read from response: %v", err)
-		}
-		if string(readBytes) != testhelpers.TestSocketList {
-			t.Errorf("expected %s, got %s", testhelpers.TestSocketList, string(readBytes))
-		}
-	})
+	tests := []struct {
+		name          string
+		cfg           *config.Config
+		expectedError bool
+	}{
+		{"Fetch With Valid Cache", newCfg(mockServer.URL, true, 10), false},
+		{"Fetch With Expired Cache", newCfg(mockServer.URL, true, 0), false},
+		{"Fetch Without Caching", newCfg(mockServer.URL, false, 0), false},
+		{"Invalid URL Without Cache", newCfg("http://badurl.com", false, 0), true},
+		{"Invalid URL With Cache", newCfg("http://badurl.com", true, 0), true},
+	}
 
-	t.Run("Fetch With Expired Cache", func(t *testing.T) {
-		filePath := testhelpers.TestFile(t, "randomhash.json", []byte(testhelpers.TestSocketList))
-		cacheDir := filepath.Dir(filePath)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := fetchSocketsFromRemote(tt.cfg)
+			if tt.expectedError {
+				if err == nil || errors.Is(err, ErrExpiredCache) {
+					t.Errorf("expected error, got %v", err)
+				}
+				return
+			}
 
-		resp, err := fetchSocketsFromRemote(mockServer.URL, true, cacheDir, 0, apiHeaderName, apiHeaderValue)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
 
-		readBytes, err := io.ReadAll(resp)
-		if err != nil {
-			t.Fatalf("failed to read from response: %v", err)
-		}
-		if string(readBytes) != testhelpers.TestSocketList {
-			t.Errorf("expected %s, got %s", testhelpers.TestSocketList, string(readBytes))
-		}
-	})
+			readBytes, err := io.ReadAll(resp)
+			if err != nil {
+				t.Fatalf("failed to read from response: %v", err)
+			}
 
-	t.Run("Fetch Without Caching", func(t *testing.T) {
-		filePath := testhelpers.TestFile(t, "randomhash.json", []byte(testhelpers.TestSocketList))
-		cacheDir := filepath.Dir(filePath)
-
-		resp, err := fetchSocketsFromRemote(mockServer.URL, false, cacheDir, 0, apiHeaderName, apiHeaderValue)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-
-		readBytes, err := io.ReadAll(resp)
-		if err != nil {
-			t.Fatalf("failed to read from response: %v", err)
-		}
-		if string(readBytes) != testhelpers.TestSocketList {
-			t.Errorf("expected %s, got %s", testhelpers.TestSocketList, string(readBytes))
-		}
-	})
-
-	t.Run("Invalid URL Without Cache Flag", func(t *testing.T) {
-		filePath := testhelpers.TestFile(t, "randomhash.json", []byte(testhelpers.TestSocketList))
-		cacheDir := filepath.Dir(filePath)
-
-		badURL := "http://badurl.com"
-
-		_, err := fetchSocketsFromRemote(badURL, false, cacheDir, 0, apiHeaderName, apiHeaderValue)
-		if err == nil {
-			t.Errorf("expected error, got none")
-		}
-	})
-
-	t.Run("Invalid URL With Cache Flag", func(t *testing.T) {
-		filePath := testhelpers.TestFile(t, "randomhash.json", []byte(testhelpers.TestSocketList))
-		cacheDir := filepath.Dir(filePath)
-
-		badURL := "http://badurl.com"
-
-		_, err := fetchSocketsFromRemote(badURL, true, cacheDir, 0, apiHeaderName, apiHeaderValue)
-		if err == nil || errors.Is(err, ErrExpiredCache) {
-			t.Errorf("expected error, got %v\n", err)
-		}
-	})
+			if string(readBytes) != testhelpers.TestSocketList {
+				t.Errorf("expected %s, got %s", testhelpers.TestSocketList, string(readBytes))
+			}
+		})
+	}
 }

--- a/pkg/socket/fetch_remote_test.go
+++ b/pkg/socket/fetch_remote_test.go
@@ -45,8 +45,7 @@ func TestFetchSocketsFromRemote(t *testing.T) {
 			// Specify temp cache file & directory for each test separately
 			// This fixes open file handles preventing the tests from succeeding on Windows
 			filePath := testhelpers.TestFile(t, "randomhash.json", []byte(testhelpers.TestSocketList))
-			cacheDir := filepath.Dir(filePath)
-			tt.cfg.ApiCacheDirectory = cacheDir
+			tt.cfg.ApiCacheDirectory = filepath.Dir(filePath)
 
 			resp, err := fetchSocketsFromRemote(tt.cfg)
 			if tt.expectedError {

--- a/pkg/socket/fetch_remote_test.go
+++ b/pkg/socket/fetch_remote_test.go
@@ -19,7 +19,7 @@ func TestFetchSocketsFromRemote(t *testing.T) {
 	filePath := testhelpers.TestFile(t, "randomhash.json", []byte(testhelpers.TestSocketList))
 	cacheDir := filepath.Dir(filePath)
 
-	newCfg := func(source string, useCache bool, ttl uint) *config.Config {
+	newConfig := func(source string, useCache bool, ttl uint) *config.Config {
 		return &config.Config{
 			Source:             source,
 			ApiCacheSockets:    useCache,
@@ -35,11 +35,11 @@ func TestFetchSocketsFromRemote(t *testing.T) {
 		cfg           *config.Config
 		expectedError bool
 	}{
-		{"Fetch With Valid Cache", newCfg(mockServer.URL, true, 10), false},
-		{"Fetch With Expired Cache", newCfg(mockServer.URL, true, 0), false},
-		{"Fetch Without Caching", newCfg(mockServer.URL, false, 0), false},
-		{"Invalid URL Without Cache", newCfg("http://badurl.com", false, 0), true},
-		{"Invalid URL With Cache", newCfg("http://badurl.com", true, 0), true},
+		{"Fetch With Valid Cache", newConfig(mockServer.URL, true, 10), false},
+		{"Fetch With Expired Cache", newConfig(mockServer.URL, true, 0), false},
+		{"Fetch Without Caching", newConfig(mockServer.URL, false, 0), false},
+		{"Invalid URL Without Cache", newConfig("http://badurl.com", false, 0), true},
+		{"Invalid URL With Cache", newConfig("http://badurl.com", true, 0), true},
 	}
 
 	for _, tt := range tests {

--- a/pkg/socket/socket.go
+++ b/pkg/socket/socket.go
@@ -61,14 +61,14 @@ func LoadSocketList(reader io.ReadCloser) (*SocketList, error) {
 }
 
 // FetchSocketList fetches the list of sockets to be checked. 'input' should be a string like '/path/filename.json', or an HTTP URL string.
-func FetchSocketList(cfg *config.Config) (*SocketList, error) {
+func FetchSocketList(config *config.Config) (*SocketList, error) {
 	var reader io.ReadCloser
 	var err error
 
-	if IsFilePath(cfg.Source) {
-		reader, err = fetchSocketsFromFile(cfg)
+	if IsFilePath(config.Source) {
+		reader, err = fetchSocketsFromFile(config)
 	} else {
-		reader, err = fetchSocketsFromRemote(cfg)
+		reader, err = fetchSocketsFromRemote(config)
 	}
 
 	if err != nil {

--- a/pkg/socket/socket.go
+++ b/pkg/socket/socket.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+
+	"go.vxn.dev/dish/pkg/config"
 )
 
 type Result struct {
@@ -59,14 +61,14 @@ func LoadSocketList(reader io.ReadCloser) (*SocketList, error) {
 }
 
 // FetchSocketList fetches the list of sockets to be checked. 'input' should be a string like '/path/filename.json', or an HTTP URL string.
-func FetchSocketList(input string, cacheSockets bool, cacheDir string, cacheTTL uint, apiHeaderName string, apiHeaderValue string) (*SocketList, error) {
+func FetchSocketList(cfg *config.Config) (*SocketList, error) {
 	var reader io.ReadCloser
 	var err error
 
-	if IsFilePath(input) {
-		reader, err = fetchSocketsFromFile(input)
+	if IsFilePath(cfg.Source) {
+		reader, err = fetchSocketsFromFile(cfg)
 	} else {
-		reader, err = fetchSocketsFromRemote(input, cacheSockets, cacheDir, cacheTTL, apiHeaderName, apiHeaderValue)
+		reader, err = fetchSocketsFromRemote(cfg)
 	}
 
 	if err != nil {

--- a/pkg/socket/socket_test.go
+++ b/pkg/socket/socket_test.go
@@ -67,7 +67,7 @@ func TestFetchSocketList(t *testing.T) {
 		t.Fatalf("failed to parse sockets string to an object: %v", err)
 	}
 
-	newCfg := func(source string) *config.Config {
+	newConfig := func(source string) *config.Config {
 		return &config.Config{
 			Source: source,
 		}
@@ -102,7 +102,7 @@ func TestFetchSocketList(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := newCfg(tt.source)
+			cfg := newConfig(tt.source)
 
 			fetchedList, err := FetchSocketList(cfg)
 			if tt.expectError {

--- a/pkg/socket/socket_test.go
+++ b/pkg/socket/socket_test.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"reflect"
 	"testing"
 
+	"go.vxn.dev/dish/pkg/config"
 	"go.vxn.dev/dish/pkg/testhelpers"
 )
 
@@ -57,53 +59,67 @@ func TestLoadSocketList(t *testing.T) {
 }
 
 func TestFetchSocketList(t *testing.T) {
-	t.Run("Fetch from file", func(t *testing.T) {
-		path := testhelpers.TestFile(t, "randomhash.json", []byte(testhelpers.TestSocketList))
+	mockServer := testhelpers.NewMockServer(t, "", "", testhelpers.TestSocketList, http.StatusOK)
+	validFile := testhelpers.TestFile(t, "randomhash.json", []byte(testhelpers.TestSocketList))
+	socketStringReader := io.NopCloser(bytes.NewBufferString(testhelpers.TestSocketList))
+	originalList, err := LoadSocketList(socketStringReader)
+	if err != nil {
+		t.Fatalf("failed to parse sockets string to an object: %v", err)
+	}
 
-		list, err := FetchSocketList(path, false, "", 0, "", "")
-		if err != nil {
-			t.Fatal(err)
+	newCfg := func(source string) *config.Config {
+		return &config.Config{
+			Source: source,
 		}
+	}
 
-		if len(list.Sockets) != 1 {
-			t.Errorf("Expected list length to be 1, got %d elements\n", len(list.Sockets))
-		}
+	tests := []struct {
+		name        string
+		source      string
+		expectError bool
+	}{
+		{
+			name:        "Fetch from file",
+			source:      validFile,
+			expectError: false,
+		},
+		{
+			name:        "Fetch from remote",
+			source:      mockServer.URL,
+			expectError: false,
+		},
+		{
+			name:        "Fetch from remote with bad URL",
+			source:      "http://invalid-host.local",
+			expectError: true,
+		},
+		{
+			name:        "Fetch from not existent file",
+			source:      "thisdoesntexist.json",
+			expectError: true,
+		},
+	}
 
-		expectedID := "vxn_dev_https"
-		if expectedID != list.Sockets[0].ID {
-			t.Errorf("Expected ID=%s, got ID=%s\n", expectedID, list.Sockets[0].ID)
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newCfg(tt.source)
 
-	t.Run("Fetch from remote", func(t *testing.T) {
-		server := testhelpers.NewMockServer(t, "", "", testhelpers.TestSocketList, http.StatusOK)
+			fetchedList, err := FetchSocketList(cfg)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error, got %v", err)
+				}
+				return
+			}
 
-		list, err := FetchSocketList(server.URL, false, "", 0, "", "")
-		if err != nil {
-			t.Fatal(err)
-		}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
 
-		if len(list.Sockets) != 1 {
-			t.Errorf("Expected list length to be 1, got %d elements\n", len(list.Sockets))
-		}
-
-		expectedID := "vxn_dev_https"
-		if expectedID != list.Sockets[0].ID {
-			t.Errorf("Expected ID=%s, got ID=%s\n", expectedID, list.Sockets[0].ID)
-		}
-	})
-
-	t.Run("Fetch from remote with bad URL", func(t *testing.T) {
-		_, err := FetchSocketList("http://invalid-host.local", false, "", 0, "", "")
-		if err == nil {
-			t.Errorf("Expected an error got nil\n")
-		}
-	})
-
-	t.Run("Fetch from not existent file", func(t *testing.T) {
-		_, err := FetchSocketList("thisdoesnotexist.json", false, "", 0, "", "")
-		if err == nil {
-			t.Errorf("Expected an error got nil\n")
-		}
-	})
+			// Manual comparison of 2 objects won't work because of expected codes type ([]int) in Socket struct
+			if !reflect.DeepEqual(fetchedList, originalList) {
+				t.Errorf("expected %+v, got %+v", originalList, fetchedList)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Hi,

This PR addresses [issue #19](https://github.com/thevxn/dish/issues/19), which affects functions that take too many parameters.

Passing too many parameters has been resolved by using a single `*Config` struct instead.

This change makes the codebase more straightforward and especially it cleans up the tests.