### PR TITLE
fix: Remove `fmt` target from `make info`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # dish / environment constatns
 
 APP_NAME=dish
-APP_VERSION=1.10.4
+APP_VERSION=1.10.5
 
 APP_FLAGS=-verbose -timeout 10 
 SOURCE=demo_sockets.json
@@ -10,4 +10,3 @@ ALPINE_VERSION=3.20
 GOLANG_VERSION=1.24
 
 DOCKER_IMAGE_TAG=${APP_NAME}:${APP_VERSION}-go${GOLANG_VERSION}
-

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # dish / environment constatns
 
 APP_NAME=dish
-APP_VERSION=1.10.5
+APP_VERSION=1.10.4
 
 APP_FLAGS=-verbose -timeout 10 
 SOURCE=demo_sockets.json

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,6 @@ all: info
 info: 
 	@echo -e "\n${GREEN} ${PROJECT_NAME} / Makefile ${RESET}\n"
 
-	@echo -e "${YELLOW} make fmt     --- reformat the go source (gofmt) ${RESET}"
 	@echo -e "${YELLOW} make test    --- run unit tests (go test) ${RESET}"
 	@echo -e "${YELLOW} make build   --- build project (docker image) ${RESET}"
 	@echo -e "${YELLOW} make run     --- run project ${RESET}"

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ make run
 
 # Run using native docker run
 docker run --rm \
- dish:1.10.5-go1.24 \
+ dish:1.10.4-go1.24 \
  -verbose \
  -target https://pushgateway.example.com \
  https://api.example.com
@@ -168,7 +168,7 @@ SOURCE_URL=https://api.example.com/dish/sockets
 UPDATE_URL=https://api.example.com/dish/sockets/results
 TARGET_URL=https://pushgw.example.com
 
-DISH_TAG=dish:1.10.5-go1.24
+DISH_TAG=dish:1.10.4-go1.24
 INSTANCE_NAME=tiny-dish
 
 API_TOKEN=AbCd

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ make run
 
 # Run using native docker run
 docker run --rm \
- dish:1.10.4-go1.24 \
+ dish:1.10.5-go1.24 \
  -verbose \
  -target https://pushgateway.example.com \
  https://api.example.com
@@ -168,7 +168,7 @@ SOURCE_URL=https://api.example.com/dish/sockets
 UPDATE_URL=https://api.example.com/dish/sockets/results
 TARGET_URL=https://pushgw.example.com
 
-DISH_TAG=dish:1.10.4-go1.24
+DISH_TAG=dish:1.10.5-go1.24
 INSTANCE_NAME=tiny-dish
 
 API_TOKEN=AbCd


### PR DESCRIPTION
This PR resolves #21 by cleaning up the `fmt` target from `Makefile` entirely.

It also bumps the patch version in the `README` and `env.example` to `1.10.5`.