### PR TITLE
refactor(netrunner): Modularize test runners by protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .env
 .vscode/*
-vendor/*
+vendor/
 cache/
 .cache/
 
@@ -12,4 +12,3 @@ main
 
 # test files
 cover*
-

--- a/cmd/dish/runner.go
+++ b/cmd/dish/runner.go
@@ -75,7 +75,7 @@ func runTests(cfg *config.Config) (*testResults, error) {
 		wg.Add(1)
 		channels[i] = make(chan socket.Result)
 
-		go netrunner.TestSocket(sock, channels[i], &wg, cfg.TimeoutSeconds, cfg.Verbose)
+		go netrunner.RunSocketTest(sock, channels[i], &wg, cfg.TimeoutSeconds, cfg.Verbose)
 		i++
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module go.vxn.dev/dish
 
 go 1.22
+
+require github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/pkg/netrunner/runner.go
+++ b/pkg/netrunner/runner.go
@@ -68,7 +68,7 @@ func (runner tcpRunner) RunTest(ctx context.Context, sock socket.Socket) socket.
 	endpoint := net.JoinHostPort(sock.Host, strconv.Itoa(sock.Port))
 
 	if runner.verbose {
-		log.Println("tcprunner: connect: " + endpoint)
+		log.Println("TCP runner: connect: " + endpoint)
 	}
 
 	d := net.Dialer{}
@@ -94,7 +94,7 @@ func (runner httpRunner) RunTest(ctx context.Context, sock socket.Socket) socket
 	url := sock.Host + ":" + strconv.Itoa(sock.Port) + sock.PathHTTP
 
 	if runner.verbose {
-		log.Println("httprunner: connect:", url)
+		log.Println("HTTP runner: connect:", url)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/pkg/netrunner/runner_test.go
+++ b/pkg/netrunner/runner_test.go
@@ -23,13 +23,15 @@ func TestRunSocketTest(t *testing.T) {
 			Host: "google.com",
 			Port: 80,
 		}
+
 		want := socket.Result{
 			Socket: sock,
 			Passed: true,
 		}
+
 		c := make(chan socket.Result)
-		done := make(chan struct{})
 		wg := &sync.WaitGroup{}
+		done := make(chan struct{})
 
 		wg.Add(1)
 		go RunSocketTest(sock, c, wg, 1, false)
@@ -39,13 +41,13 @@ func TestRunSocketTest(t *testing.T) {
 			done <- struct{}{}
 		}()
 
+		got := <-c
+
 		select {
 		case <-done:
 		case <-time.After(time.Second):
 			t.Fatalf("RunSocketTest: timed out waiting for the test results")
 		}
-
-		got := <-c
 
 		select {
 		// Once the test is finished no further results are sent.

--- a/pkg/netrunner/runner_test.go
+++ b/pkg/netrunner/runner_test.go
@@ -1,0 +1,274 @@
+package netrunner
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.vxn.dev/dish/pkg/socket"
+)
+
+// TestRunSocketTest is an integration test. It executes network calls to
+// external public servers.
+func TestRunSocketTest(t *testing.T) {
+	t.Run("output chan is closed and the wait group is not blocking after a successful concurrent test", func(t *testing.T) {
+		sock := socket.Socket{
+			ID:   "google_tcp",
+			Name: "Google TCP",
+			Host: "google.com",
+			Port: 80,
+		}
+		want := socket.Result{
+			Socket: sock,
+			Passed: true,
+		}
+		c := make(chan socket.Result)
+		done := make(chan struct{})
+		wg := &sync.WaitGroup{}
+
+		wg.Add(1)
+		go RunSocketTest(sock, c, wg, 1, false)
+
+		go func() {
+			wg.Wait()
+			done <- struct{}{}
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatalf("RunSocketTest: timed out waiting for the test results")
+		}
+
+		got := <-c
+
+		select {
+		// Once the test is finished no further results are sent.
+		// If this select case blocks instead of reading the default immediately value then the channel is not closed.
+		case <-c:
+		default:
+			t.Error("RunSocketTest: the output channel has not been closed after returning")
+		}
+
+		if !cmp.Equal(got, want) {
+			t.Fatalf("RunSocketTest:\n want = %v\n got = %v\n", want, got)
+		}
+	})
+}
+
+func TestNewNetRunner(t *testing.T) {
+	type args struct {
+		verbose bool
+		sock    socket.Socket
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    NetRunner
+		wantErr bool
+	}{
+		{
+			name: "returns a httpRunner when given an HTTPs socket",
+			args: args{
+				verbose: false,
+				sock: socket.Socket{
+					ID:                "google_https",
+					Name:              "Google HTTPs",
+					Host:              "https://google.com",
+					Port:              443,
+					ExpectedHTTPCodes: []int{200},
+					PathHTTP:          "/",
+				},
+			},
+			want: httpRunner{
+				client:  &http.Client{},
+				verbose: false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "returns a httpRunner when given a HTTP socket",
+			args: args{
+				verbose: false,
+				sock: socket.Socket{
+					ID:                "google_http",
+					Name:              "Google HTTP",
+					Host:              "http://www.google.com",
+					Port:              80,
+					ExpectedHTTPCodes: []int{200},
+					PathHTTP:          "/",
+				},
+			},
+			want: httpRunner{
+				client:  &http.Client{},
+				verbose: false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "returns a tcpRunner when given a TCP socket",
+			args: args{
+				verbose: false,
+				sock: socket.Socket{
+					ID:                "",
+					Name:              "",
+					Host:              "",
+					Port:              80,
+					ExpectedHTTPCodes: []int{200},
+					PathHTTP:          "/",
+				},
+			},
+			want:    tcpRunner{verbose: false},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewNetRunner(tt.args.sock, tt.args.verbose)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewNetRunner():\n error = %v\n wantErr = %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewNetRunner():\n got = %v\n want = %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTcpRunner_RunTest is an integration test. It executes network calls to
+// external public servers.
+func TestTcpRunner_RunTest(t *testing.T) {
+	type fields struct {
+		verbose bool
+	}
+	type args struct {
+		sock socket.Socket
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   socket.Result
+	}{
+		{
+			name: "returns a success on a call to a valid TCP server",
+			fields: fields{
+				verbose: false,
+			},
+			args: args{
+				sock: socket.Socket{
+					ID:   "google_tcp",
+					Name: "Google TCP",
+					Host: "google.com",
+					Port: 80,
+				},
+			},
+			want: socket.Result{
+				Socket: socket.Socket{
+					ID:   "google_tcp",
+					Name: "Google TCP",
+					Host: "google.com",
+					Port: 80,
+				},
+				Passed: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := tcpRunner{tt.fields.verbose}
+
+			if got := r.RunTest(context.Background(), tt.args.sock); !cmp.Equal(got, tt.want) {
+				t.Errorf("tcpRunner.RunTest():\n got = %v\n want = %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHttpRunner_RunTest is an integration test. It executes network calls to
+// external public servers.
+func TestHttpRunner_RunTest(t *testing.T) {
+	type args struct {
+		sock socket.Socket
+	}
+	tests := []struct {
+		name   string
+		runner httpRunner
+		args   args
+		want   socket.Result
+	}{
+		{
+			name:   "returns a success on a call to a valid HTTPs server",
+			runner: httpRunner{client: &http.Client{}, verbose: false},
+			args: args{
+				sock: socket.Socket{
+					ID:                "google_http",
+					Name:              "Google HTTP",
+					Host:              "https://www.google.com",
+					Port:              443,
+					ExpectedHTTPCodes: []int{200},
+					PathHTTP:          "/",
+				},
+			},
+			want: socket.Result{
+				Socket: socket.Socket{
+					ID:                "google_http",
+					Name:              "Google HTTP",
+					Host:              "https://www.google.com",
+					Port:              443,
+					ExpectedHTTPCodes: []int{200},
+					PathHTTP:          "/",
+				},
+				Passed:       true,
+				ResponseCode: 200,
+			},
+		},
+		{
+			name: "returns a failure on a call to an invalid HTTPs server",
+			// The since both DNS and HTTPs use TCP the conn opens successfully but
+			// the request timeouts while awaiting HTTP headers.
+			runner: httpRunner{client: &http.Client{Timeout: time.Second}, verbose: false},
+			args: args{
+				sock: socket.Socket{
+					ID:                "cloudflare_dns",
+					Name:              "Cloudflare DNS",
+					Host:              "https://1.1.1.1",
+					Port:              53,
+					ExpectedHTTPCodes: []int{200},
+					PathHTTP:          "/",
+				},
+			},
+			want: socket.Result{
+				Socket: socket.Socket{
+					ID:                "cloudflare_dns",
+					Name:              "Cloudflare DNS",
+					Host:              "https://1.1.1.1",
+					Port:              53,
+					ExpectedHTTPCodes: []int{200},
+					PathHTTP:          "/",
+				},
+				Passed: false,
+				Error:  cmpopts.AnyError,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.runner.RunTest(context.Background(), tt.args.sock)
+			if !cmp.Equal(got, tt.want, cmpopts.EquateErrors()) {
+				t.Errorf("httpRunner.RunTest():\n got = %v\n want = %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/netrunner/runner_test.go
+++ b/pkg/netrunner/runner_test.go
@@ -49,7 +49,7 @@ func TestRunSocketTest(t *testing.T) {
 
 		select {
 		// Once the test is finished no further results are sent.
-		// If this select case blocks instead of reading the default immediately value then the channel is not closed.
+		// If this select case blocks instead of reading the default value immediately then the channel is not closed.
 		case <-c:
 		default:
 			t.Error("RunSocketTest: the output channel has not been closed after returning")


### PR DESCRIPTION
# NetRunner
This PR introduces the `NetRunner` interface to the netrunner package along with `httpRunner` and `tcpRunner` that implement it.

## TestSocket
`TestSocket` function is now renamed to `RunSocketTest` to avoid confusion with its test (according to the convention it would be named `TestTestSocket`). It still acts as the main entrypoint for the package's functionality.

`RunSocketTest` now does not do any tests by itself and instead delegates the testing logic to the NetRunners. It uses the `NewNetRunner` factory to create the right NetRunner depending on the protocol determined for the socket.

This design allows to add support for new protocols with little to no changes in the existing implementation. Once this PR is resolved I'll begin implementing #18. 

## First dependency
The [`github.com/google/go-cmp`](https://github.com/google/go-cmp) module is added as a test-only dependency as a safer alternative to `reflect.DeepEqual`. The `cmp` package allows to reliably compare normally non-comparable types such as errors, times, slices and maps, allowing for custom equality rules where needed.
The dish itself still has zero deps.

---
Related to #14 since this PR adds unit and integration tests for `RunSocketTest` and all `NetRunner` implementations. 