### PR TITLE
feat(netrunner): Add support for ICMP tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24'
+      - name: Set global ping privileges
+        run: |
+          # Allow everyone to use ping.
+          sudo sysctl -w net.ipv4.ping_group_range="0 2147483647" 
       - name: Build
         run: go build -v ./cmd/...
       - name: Test
@@ -44,6 +48,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24'
+      - name: Set global ping privileges
+        run: |
+          # Allow everyone to use ping.
+          sudo sysctl -w net.ipv4.ping_group_range="0 2147483647" 
       - name: Build
         run: go build -v ./cmd/...
       - name: Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Build
         run: go build -v ./cmd/...
       - name: Test
-        run: go test -v ./...
+        # Github Actions cloud runners block any incoming ICMP packets.
+        run: go test -v ./... -skip 'TestIcmpRunner_RunTest'
         
   windows_x64:
     runs-on: windows-2025
@@ -38,7 +39,8 @@ jobs:
       - name: Build
         run: go build -v ./cmd/...
       - name: Test
-        run: go test -v ./...
+        # Github Actions cloud runners block any incoming ICMP packets.
+        run: go test -v ./... -skip 'TestIcmpRunner_RunTest'
         
   linux_arm64:
     runs-on: ubuntu-24.04-arm
@@ -55,7 +57,8 @@ jobs:
       - name: Build
         run: go build -v ./cmd/...
       - name: Test
-        run: go test -v ./...
+        # Github Actions cloud runners block any incoming ICMP packets.
+        run: go test -v ./... -skip 'TestIcmpRunner_RunTest'
 
   # windows_arm64:
   #   runs-on: windows-11-arm
@@ -68,7 +71,8 @@ jobs:
   #     - name: Build
   #       run: go build -v ./cmd/...
   #     - name: Test
-  #       run: go test -v ./...
+  # Github Actions cloud runners block any incoming ICMP packets.
+  #       run: go test -v ./... -skip 'TestIcmpRunner_RunTest'
 
   macOS_intel:
     runs-on: macos-13
@@ -81,7 +85,8 @@ jobs:
       - name: Build
         run: go build -v ./cmd/...
       - name: Test
-        run: go test -v ./...
+        # Github Actions cloud runners block any incoming ICMP packets.
+        run: go test -v ./... -skip 'TestIcmpRunner_RunTest'
 
   macOS_arm64:
     runs-on: macos-latest
@@ -94,7 +99,8 @@ jobs:
       - name: Build
         run: go build -v ./cmd/...
       - name: Test
-        run: go test -v ./...
+        # Github Actions cloud runners block any incoming ICMP packets.
+        run: go test -v ./... -skip 'TestIcmpRunner_RunTest'
     
   # Self-hosted runner mainly intended for running ICMP integration tests which cannot be run in the GH runners due to incoming traffic being blocked
   self-hosted:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24'
-      - name: Set global ping privileges
-        run: |
-          # Allow everyone to use ping.
-          sudo sysctl -w net.ipv4.ping_group_range="0 2147483647" 
       - name: Build
         run: go build -v ./cmd/...
       - name: Test
@@ -50,10 +46,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24'
-      - name: Set global ping privileges
-        run: |
-          # Allow everyone to use ping.
-          sudo sysctl -w net.ipv4.ping_group_range="0 2147483647" 
       - name: Build
         run: go build -v ./cmd/...
       - name: Test

--- a/pkg/netrunner/runner.go
+++ b/pkg/netrunner/runner.go
@@ -17,11 +17,10 @@ import (
 
 const agentVersion = "1.10"
 
-// RunSocketTest is meant to be invoked in a separate goroutine.
-// It runs a test for the given socket. The test result is sent through the given
-// channel. If the test fails to start then the error is logged to stdout and no
-// result is sent. When this func returns, it calls Done() on the WaitGroup and
-// the channel is closed.
+// RunSocketTest is intended to be invoked in a separate goroutine.
+// It runs a test for the given socket and sends the result through the given channel.
+// If the test fails to start, the error is logged to STDOUT and no result is
+// sent. On return, Done() is called on the WaitGroup and the channel is closed.
 func RunSocketTest(sock socket.Socket, out chan<- socket.Result, wg *sync.WaitGroup, timeoutSeconds uint, verbose bool) {
 	defer wg.Done()
 	defer close(out)

--- a/pkg/netrunner/runner.go
+++ b/pkg/netrunner/runner.go
@@ -2,7 +2,6 @@ package netrunner
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -70,7 +69,7 @@ func NewNetRunner(sock socket.Socket, verbose bool) (NetRunner, error) {
 		return icmpRunner{verbose: verbose}, nil
 	}
 
-	return nil, errors.New("no protocol could be determined from the socket")
+	return nil, fmt.Errorf("no protocol could be determined from the socket %s", sock.ID)
 }
 
 type tcpRunner struct {

--- a/pkg/netrunner/runner_posix.go
+++ b/pkg/netrunner/runner_posix.go
@@ -1,0 +1,105 @@
+//go:build linux || darwin
+
+package netrunner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"syscall"
+	"time"
+
+	"go.vxn.dev/dish/pkg/socket"
+)
+
+type icmpRunner struct {
+	verbose bool
+}
+
+// RunTest is used to test ICMP sockets. It sends an ICMP Echo Request to the given socket using
+// non-privileged ICMP and verifies the reply. The test passes if the reply has the same payload
+// as the request. Returns an error if the socket host cannot resolve to an IP address. If the host
+// resolves to more than one address, only the first one is tested.
+func (runner icmpRunner) RunTest(ctx context.Context, sock socket.Socket) socket.Result {
+	if runner.verbose {
+		log.Printf("Resolving host '%s' to an IP address", sock.Host)
+	}
+
+	addr, err := net.DefaultResolver.LookupIP(ctx, "ip", sock.Host)
+	if err != nil {
+		return socket.Result{Socket: sock, Error: fmt.Errorf("failed to resolve socket host: %w", err)}
+	}
+
+	ip := addr[0]
+
+	sockAddr := &syscall.SockaddrInet4{Addr: [4]byte(ip)}
+
+	if runner.verbose {
+		log.Println("ICMP runner: send to " + ip.String())
+	}
+
+	// When using ICMP over DGRAM, Linux Kernel automatically sets (overwrites) and
+	// validates the id, seq and checksum of each incoming and outgoing ICMP message.
+	// This is largely non-documented in the linux man pages. The closest I found is:
+	// - (Linux news) lwn.net/Articles/420800/
+	// - (MacOS man) https://www.manpagez.com/man/4/icmp/
+	// - (Third-party article) https://inc0x0.com/icmp-ip-packets-ping-manually-create-and-send-icmp-ip-packets/
+	// "[...] most Linux systems use a unique identifier for every ping process, and sequence
+	// number is an increasing number within that process. Windows uses a fixed identifier, which
+	// varies between Windows versions, and a sequence number that is only reset at boot time."
+	sysSocket, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, syscall.IPPROTO_ICMP)
+	if err != nil {
+		return socket.Result{Socket: sock, Error: fmt.Errorf("failed to create a non-privileged icmp socket: %w", err)}
+	}
+	defer syscall.Close(sysSocket)
+
+	if d, ok := ctx.Deadline(); ok {
+		// Set a socket receive timeout.
+		t := syscall.NsecToTimeval(time.Until(d).Nanoseconds())
+		if err := syscall.SetsockoptTimeval(sysSocket, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &t); err != nil {
+			return socket.Result{Socket: sock, Error: fmt.Errorf("failed to set a timeout on a non-privileged icmp socket: %w", err)}
+		}
+	}
+
+	payload := []byte("ICMP echo")
+
+	// ICMP Header size is 8 bytes.
+	reqBuf := make([]byte, 8+len(payload))
+
+	// ICMP Header.
+	// ID, Seq and Checksum are filled in automatically by the kernel.
+	reqBuf[0] = 8 // Type: Echo
+
+	copy(reqBuf[8:], payload)
+
+	if err := syscall.Sendto(sysSocket, reqBuf, 0, sockAddr); err != nil {
+		return socket.Result{Socket: sock, Error: fmt.Errorf("failed to send an echo request: %w", err)}
+	}
+
+	// Maximum Transmission Unit (MTU) equals 1500 bytes.
+	// Recvfrom before writing to the buffer, checks its length (not capacity).
+	// If the length of the buffer is too small to fit the data then it's silently truncated.
+	replyBuf := make([]byte, 1500)
+
+	n, _, err := syscall.Recvfrom(sysSocket, replyBuf, 0)
+	if err != nil {
+		return socket.Result{Socket: sock, Error: fmt.Errorf("failed to receive a reply from a socket: %w", err)}
+	}
+
+	if n < 8 {
+		return socket.Result{Socket: sock, Error: fmt.Errorf("reply is too short: received %d bytes ", n)}
+	}
+
+	if replyBuf[0] != 0 {
+		return socket.Result{Socket: sock, Error: errors.New("received unexpected reply type")}
+	}
+
+	if !bytes.Equal(reqBuf[8:], replyBuf[8:n]) {
+		return socket.Result{Socket: sock, Error: errors.New("failed to validate echo reply: payloads are not equal")}
+	}
+
+	return socket.Result{Socket: sock, Passed: true}
+}

--- a/pkg/netrunner/runner_posix.go
+++ b/pkg/netrunner/runner_posix.go
@@ -21,14 +21,14 @@ type icmpRunner struct {
 
 // RunTest is used to test ICMP sockets. It sends an ICMP Echo Request to the given socket using
 // non-privileged ICMP and verifies the reply. The test passes if the reply has the same payload
-// as the request. Returns an error if the socket host cannot resolve to an IP address. If the host
-// resolves to more than one address, only the first one is tested.
+// as the request. Returns an error if the socket host cannot be resolved to an IPv4 address. If
+// the host resolves to more than one address, only the first one is used.
 func (runner icmpRunner) RunTest(ctx context.Context, sock socket.Socket) socket.Result {
 	if runner.verbose {
 		log.Printf("Resolving host '%s' to an IP address", sock.Host)
 	}
 
-	addr, err := net.DefaultResolver.LookupIP(ctx, "ip", sock.Host)
+	addr, err := net.DefaultResolver.LookupIP(ctx, "ip4", sock.Host)
 	if err != nil {
 		return socket.Result{Socket: sock, Error: fmt.Errorf("failed to resolve socket host: %w", err)}
 	}

--- a/pkg/netrunner/runner_posix.go
+++ b/pkg/netrunner/runner_posix.go
@@ -37,10 +37,6 @@ func (runner icmpRunner) RunTest(ctx context.Context, sock socket.Socket) socket
 
 	sockAddr := &syscall.SockaddrInet4{Addr: [4]byte(ip)}
 
-	if runner.verbose {
-		log.Println("ICMP runner: send to " + ip.String())
-	}
-
 	// When using ICMP over DGRAM, Linux Kernel automatically sets (overwrites) and
 	// validates the id, seq and checksum of each incoming and outgoing ICMP message.
 	// This is largely non-documented in the linux man pages. The closest I found is:
@@ -75,6 +71,10 @@ func (runner icmpRunner) RunTest(ctx context.Context, sock socket.Socket) socket
 
 	copy(reqBuf[8:], payload)
 
+	if runner.verbose {
+		log.Println("ICMP runner: send to " + ip.String())
+	}
+
 	if err := syscall.Sendto(sysSocket, reqBuf, 0, sockAddr); err != nil {
 		return socket.Result{Socket: sock, Error: fmt.Errorf("failed to send an echo request: %w", err)}
 	}
@@ -83,6 +83,10 @@ func (runner icmpRunner) RunTest(ctx context.Context, sock socket.Socket) socket
 	// Recvfrom before writing to the buffer, checks its length (not capacity).
 	// If the length of the buffer is too small to fit the data then it's silently truncated.
 	replyBuf := make([]byte, 1500)
+
+	if runner.verbose {
+		log.Println("ICMP runner: recv from " + ip.String())
+	}
 
 	n, _, err := syscall.Recvfrom(sysSocket, replyBuf, 0)
 	if err != nil {

--- a/pkg/netrunner/runner_test.go
+++ b/pkg/netrunner/runner_test.go
@@ -373,6 +373,28 @@ func TestIcmpRunner_RunTest(t *testing.T) {
 				Error:  cmpopts.AnyError,
 			},
 		},
+		{
+			name: "returns an error on an invalid IP address",
+			runner: icmpRunner{
+				verbose: testing.Verbose(),
+			},
+			args: args{
+				sock: socket.Socket{
+					ID:   "invalid_ip",
+					Name: "Invalid IP",
+					Host: "256.100.50.25",
+				},
+			},
+			want: socket.Result{
+				Socket: socket.Socket{
+					ID:   "invalid_ip",
+					Name: "Invalid IP",
+					Host: "256.100.50.25",
+				},
+				Passed: false,
+				Error:  cmpopts.AnyError,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/netrunner/runner_test.go
+++ b/pkg/netrunner/runner_test.go
@@ -77,7 +77,7 @@ func TestNewNetRunner(t *testing.T) {
 		{
 			name: "returns an httpRunner when given an HTTPs socket",
 			args: args{
-				verbose: false,
+				verbose: testing.Verbose(),
 				sock: socket.Socket{
 					ID:                "google_https",
 					Name:              "Google HTTPs",
@@ -89,14 +89,14 @@ func TestNewNetRunner(t *testing.T) {
 			},
 			want: httpRunner{
 				client:  &http.Client{},
-				verbose: false,
+				verbose: testing.Verbose(),
 			},
 			wantErr: false,
 		},
 		{
 			name: "returns an httpRunner when given a HTTP socket",
 			args: args{
-				verbose: false,
+				verbose: testing.Verbose(),
 				sock: socket.Socket{
 					ID:                "google_http",
 					Name:              "Google HTTP",
@@ -108,24 +108,21 @@ func TestNewNetRunner(t *testing.T) {
 			},
 			want: httpRunner{
 				client:  &http.Client{},
-				verbose: false,
+				verbose: testing.Verbose(),
 			},
 			wantErr: false,
 		},
 		{
 			name: "returns a tcpRunner when given a TCP socket",
 			args: args{
-				verbose: false,
+				verbose: testing.Verbose(),
 				sock: socket.Socket{
-					ID:                "",
-					Name:              "",
-					Host:              "",
 					Port:              80,
 					ExpectedHTTPCodes: []int{200},
 					PathHTTP:          "/",
 				},
 			},
-			want:    tcpRunner{verbose: false},
+			want:    tcpRunner{verbose: testing.Verbose()},
 			wantErr: false,
 		},
 	}
@@ -166,7 +163,7 @@ func TestTcpRunner_RunTest(t *testing.T) {
 		{
 			name: "returns a success on a call to a valid TCP server",
 			fields: fields{
-				verbose: false,
+				verbose: testing.Verbose(),
 			},
 			args: args{
 				sock: socket.Socket{
@@ -212,7 +209,7 @@ func TestHttpRunner_RunTest(t *testing.T) {
 	}{
 		{
 			name:   "returns a success on a call to a valid HTTPs server",
-			runner: httpRunner{client: &http.Client{}, verbose: false},
+			runner: httpRunner{client: &http.Client{}, verbose: testing.Verbose()},
 			args: args{
 				sock: socket.Socket{
 					ID:                "google_http",
@@ -240,7 +237,7 @@ func TestHttpRunner_RunTest(t *testing.T) {
 			name: "returns a failure on a call to an invalid HTTPs server",
 			// The since both DNS and HTTPs use TCP the conn opens successfully but
 			// the request timeouts while awaiting HTTP headers.
-			runner: httpRunner{client: &http.Client{Timeout: time.Second}, verbose: false},
+			runner: httpRunner{client: &http.Client{Timeout: time.Second}, verbose: testing.Verbose()},
 			args: args{
 				sock: socket.Socket{
 					ID:                "cloudflare_dns",

--- a/pkg/netrunner/runner_test.go
+++ b/pkg/netrunner/runner_test.go
@@ -75,7 +75,7 @@ func TestNewNetRunner(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "returns a httpRunner when given an HTTPs socket",
+			name: "returns an httpRunner when given an HTTPs socket",
 			args: args{
 				verbose: false,
 				sock: socket.Socket{
@@ -94,7 +94,7 @@ func TestNewNetRunner(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "returns a httpRunner when given a HTTP socket",
+			name: "returns an httpRunner when given a HTTP socket",
 			args: args{
 				verbose: false,
 				sock: socket.Socket{

--- a/pkg/netrunner/runner_test.go
+++ b/pkg/netrunner/runner_test.go
@@ -376,7 +376,10 @@ func TestIcmpRunner_RunTest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.runner.RunTest(context.Background(), tt.args.sock)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			got := tt.runner.RunTest(ctx, tt.args.sock)
 			if !cmp.Equal(got, tt.want, cmpopts.EquateErrors()) {
 				t.Fatalf("icmpRunner.RunTest():\n got = %v\n want = %v", got, tt.want)
 			}

--- a/pkg/netrunner/runner_windows.go
+++ b/pkg/netrunner/runner_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package netrunner
+
+import (
+	"context"
+	"errors"
+
+	"go.vxn.dev/dish/pkg/socket"
+)
+
+type icmpRunner struct {
+	verbose bool
+}
+
+func (runner icmpRunner) RunTest(ctx context.Context, sock socket.Socket) socket.Result {
+	return socket.Result{Socket: sock, Error: errors.New("icmp tests on windows are not implemented")}
+}


### PR DESCRIPTION
# ICMP Tests

This PR closes #18 by adding a new socket testing method: an **ICMP Ping**.

*ICMP tests are currently only supported on Linux and MacOS. ICMP tests on Windows will always fail with a descriptive error.*

In order to implement ICMP test without breaking existing socket sources, a new set of test determination rules is introduced:
  - If host_name starts with 'http://' or 'https://', an HTTP test is executed.
  - If port_tcp is between 1 and 65535, a TCP test is executed.
  - If host_name is not empty, an ICMP test is executed.
  - If none of the above conditions are met, the test fails with an error.

First matching rule applies. This change is backwards compatible with existing socket sources.

Example source file for an ICMP Ping test can look like this:
```jsonc
{
  "sockets": [
    {
      "id": "vxn_dev_icmp",
      "socket_name": "vxn-dev ICMP",
      "host_name": "vxn.dev", // Can also be an IPv4 address.
      "port_tcp": 0,
      "path_http": "",
      "expected_http_code_array": []
    }
  ]
}

```
When fed this sourcefile, dish tries to resolve the `host_name` to an IPv4 address (IPv6 is not supported) and executes a single ICMP Echo Request to this address. If the `host_name` resolves to multiple addresses, dish tests only the first match. Then dish listens for a single ICMP Echo Reply and verifies it. If the reply is valid then the socket passes the test.