### PR TITLE
Add discord notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Usage of dish:
         a string, specifies the directory used to cache the socket list fetched from the remote API source (default ".cache")
   -cacheTTL uint
         an int, time duration (in minutes) for which the cached list of sockets is valid (default 10)
+  -discordBotToken string
+        a string, Discord bot token
+  -discordChannelId string
+        a string, Discord channel ID
   -hname string
         a string, name of a custom additional header to be used when fetching and pushing results to the remote API (used mainly for auth purposes)
   -hvalue string
@@ -122,10 +126,11 @@ When a socket test fails, it's always good to be notified. For this purpose, dis
 + Check results as the Telegram message body (via the `-telegramBotToken` and `-telegramChatID` flags)
 + Failed count and last test timestamp update to Pushgateway for Prometheus (using the `-target` flag)
 + Test results push to a webhook URL (using the `-webhookURL` flag)
++ Check results as a Discord message (via the `-discordBotToken` and `-discordChannelId` flags)
 
 Whether successful runs with no failed checks should be reported can also be configured using flags:
 
-+ `-textNotifySuccess` for text channels (e.g. Telegram)
++ `-textNotifySuccess` for text channels (e.g. Telegram, Discord)
 + `-machineNotifySuccess` for machine channels (e.g. webhooks, remote API or Pushgateway)
 
 ![telegram-alerting](/.github/dish_telegram.png)

--- a/pkg/alert/discord.go
+++ b/pkg/alert/discord.go
@@ -1,0 +1,81 @@
+package alert
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"go.vxn.dev/dish/pkg/config"
+	"go.vxn.dev/dish/pkg/logger"
+)
+
+type discordSender struct {
+	botToken      string
+	channelID     string
+	httpClient    HTTPClient
+	logger        logger.Logger
+	notifySuccess bool
+}
+
+const (
+	discordBaseURL         = "https://discord.com/api/v10"
+	discordSendMessagePath = "/channels/%s/messages"
+	discordSendMessageURL  = discordBaseURL + discordSendMessagePath
+)
+
+func NewDiscordSender(httpClient HTTPClient, config *config.Config, logger logger.Logger) ChatNotifier {
+	return &discordSender{
+		botToken:      config.DiscordBotToken,
+		channelID:     config.DiscordChannelID,
+		httpClient:    httpClient,
+		logger:        logger,
+		notifySuccess: config.TextNotifySuccess,
+	}
+
+}
+
+func (s *discordSender) send(message string, failedCount int) error {
+	// If no checks failed and success should not be notified, there is nothing to send
+	if failedCount == 0 && !s.notifySuccess {
+		s.logger.Debug("no sockets failed, nothing will be sent to Telegram")
+
+		return nil
+	}
+
+	formattedSendURL := fmt.Sprintf(discordSendMessageURL, s.channelID)
+
+	payload := map[string]string{
+		"content": message,
+	}
+	body, err := json.Marshal(payload)
+
+	if err != nil {
+		return fmt.Errorf("error submitting discord alert: %w ", err)
+	}
+
+	req, err := http.NewRequest("POST", formattedSendURL, bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("error submitting discord alert: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bot %s", s.botToken))
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error submitting discord alert: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return errors.New("error submitting discord alert: non-success status code")
+	}
+
+	s.logger.Debug("discord message sent")
+	return nil
+}
+
+// Test token : AR7DbyW7CL3HxQiDeyLq-aZfaL9jnV_8
+// Test channel: 1391401731329622036/1391401732046585888

--- a/pkg/alert/discord.go
+++ b/pkg/alert/discord.go
@@ -49,7 +49,7 @@ func (s *discordSender) send(message string, failedCount int) error {
 		return nil
 	}
 
-	formattedSendURL := fmt.Sprintf(discordMessagesURL, s.channelID)
+	formattedSendURL := fmt.Sprintf(discordMessagesURL, strings.TrimSpace(s.channelID))
 
 	payload := discordMessagePayload{
 		Content: message,

--- a/pkg/alert/discord.go
+++ b/pkg/alert/discord.go
@@ -21,6 +21,7 @@ type discordSender struct {
 
 type discordMessagePayload struct {
 	Content string `json:"content"`
+	Flags   int    `json:"flags,omitempty"`
 }
 
 const (
@@ -50,7 +51,10 @@ func (s *discordSender) send(message string, failedCount int) error {
 
 	formattedSendURL := fmt.Sprintf(discordMessagesURL, s.channelID)
 
-	payload := discordMessagePayload{Content: message}
+	payload := discordMessagePayload{
+		Content: message,
+		Flags:   4, // Suppress embedded links in the message
+	}
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("error submitting discord alert: %w ", err)

--- a/pkg/alert/discord_test.go
+++ b/pkg/alert/discord_test.go
@@ -1,0 +1,129 @@
+package alert
+
+import (
+	"reflect"
+	"testing"
+
+	"go.vxn.dev/dish/pkg/config"
+)
+
+func TestNewDiscordSender(t *testing.T) {
+	mockHTTPClient := &SuccessStatusHTTPClient{}
+	mockLogger := &MockLogger{}
+
+	testBotToken := "test"
+	testChannelID := "-123"
+
+	expected := &discordSender{
+		botToken:      testBotToken,
+		channelID:     testChannelID,
+		httpClient:    mockHTTPClient,
+		logger:        mockLogger,
+		notifySuccess: false,
+	}
+
+	cfg := &config.Config{
+		DiscordBotToken:   testBotToken,
+		DiscordChannelID:  testChannelID,
+		TextNotifySuccess: false,
+	}
+
+	actual := NewDiscordSender(mockHTTPClient, cfg, mockLogger)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
+}
+
+func TestSend_Discord(t *testing.T) {
+	newConfig := func(botToken, channelID string, notifySuccess bool) *config.Config {
+		return &config.Config{
+			DiscordBotToken:   botToken,
+			DiscordChannelID:  channelID,
+			TextNotifySuccess: notifySuccess,
+		}
+	}
+
+	tests := []struct {
+		name          string
+		client        HTTPClient
+		rawMessage    string
+		failedCount   int
+		notifySuccess bool
+		wantErr       bool
+	}{
+		{
+			name:          "success with failed checks",
+			client:        &SuccessStatusHTTPClient{},
+			rawMessage:    "Test message",
+			failedCount:   1,
+			notifySuccess: false,
+			wantErr:       false,
+		},
+		{
+			name:          "success with failed checks",
+			client:        &SuccessStatusHTTPClient{},
+			rawMessage:    "Test message",
+			failedCount:   1,
+			notifySuccess: true,
+			wantErr:       false,
+		},
+		{
+			name:          "success with failed checks",
+			client:        &SuccessStatusHTTPClient{},
+			rawMessage:    "Test message",
+			failedCount:   0,
+			notifySuccess: false,
+			wantErr:       false,
+		},
+		{
+			name:          "success with no failed checks and notify success enabled",
+			client:        &SuccessStatusHTTPClient{},
+			rawMessage:    "Test message",
+			failedCount:   0,
+			notifySuccess: true,
+			wantErr:       false,
+		},
+		{
+			name:          "Network Error When Sending Discord Message",
+			client:        &FailureHTTPClient{},
+			rawMessage:    "Test message",
+			failedCount:   1,
+			notifySuccess: false,
+			wantErr:       true,
+		},
+		{
+			name:          "Network Error When Sending Discord Message",
+			client:        &FailureHTTPClient{},
+			rawMessage:    "Test message",
+			failedCount:   1,
+			notifySuccess: false,
+			wantErr:       true,
+		},
+		{
+			name:          "Unexpected Response Code From Discord",
+			client:        &ErrorStatusHTTPClient{},
+			rawMessage:    "Test message",
+			failedCount:   1,
+			notifySuccess: false,
+			wantErr:       true,
+		},
+		{
+			name:          "Error Reading Response Body From Discord",
+			client:        &InvalidResponseBodyHTTPClient{},
+			rawMessage:    "Test message",
+			failedCount:   1,
+			notifySuccess: false,
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sender := NewDiscordSender(tt.client, newConfig("test", "-123", tt.notifySuccess), &MockLogger{})
+			err := sender.send(tt.rawMessage, tt.failedCount)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("send() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/alert/discord_test.go
+++ b/pkg/alert/discord_test.go
@@ -11,26 +11,64 @@ func TestNewDiscordSender(t *testing.T) {
 	mockHTTPClient := &SuccessStatusHTTPClient{}
 	mockLogger := &MockLogger{}
 
-	testBotToken := "test"
-	testChannelID := "-123"
-
-	expected := &discordSender{
-		botToken:      testBotToken,
-		channelID:     testChannelID,
-		httpClient:    mockHTTPClient,
-		logger:        mockLogger,
-		notifySuccess: false,
+	tests := []struct {
+		name           string
+		botToken       string
+		channelID      string
+		notifySuccess  bool
+		expectErr      bool
+		expectedSender *discordSender
+	}{
+		{
+			name:          "successful sender creation",
+			botToken:      "test",
+			channelID:     "-123",
+			notifySuccess: false,
+			expectErr:     false,
+			expectedSender: &discordSender{
+				botToken:      "test",
+				channelID:     "-123",
+				httpClient:    mockHTTPClient,
+				logger:        mockLogger,
+				notifySuccess: false,
+				url:           "https://discord.com/api/v10/channels/-123/messages",
+			},
+		},
+		{
+			name:           "invalid channel ID returns error",
+			botToken:       "test",
+			channelID:      "1%ZZ",
+			notifySuccess:  false,
+			expectErr:      true,
+			expectedSender: nil,
+		},
 	}
 
-	cfg := &config.Config{
-		DiscordBotToken:   testBotToken,
-		DiscordChannelID:  testChannelID,
-		TextNotifySuccess: false,
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				DiscordBotToken:   tt.botToken,
+				DiscordChannelID:  tt.channelID,
+				TextNotifySuccess: tt.notifySuccess,
+			}
 
-	actual := NewDiscordSender(mockHTTPClient, cfg, mockLogger)
-	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("expected %v, got %v", expected, actual)
+			actual, err := NewDiscordSender(mockHTTPClient, cfg, mockLogger)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(tt.expectedSender, actual) {
+				t.Errorf("expected %+v, got %+v", tt.expectedSender, actual)
+			}
+		})
 	}
 }
 
@@ -119,7 +157,7 @@ func TestSend_Discord(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sender := NewDiscordSender(tt.client, newConfig("test", "-123", tt.notifySuccess), &MockLogger{})
+			sender, _ := NewDiscordSender(tt.client, newConfig("test", "-123", tt.notifySuccess), &MockLogger{})
 			err := sender.send(tt.rawMessage, tt.failedCount)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("send() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/alert/formatter.go
+++ b/pkg/alert/formatter.go
@@ -33,3 +33,7 @@ func FormatMessengerText(result socket.Result) string {
 
 	return text
 }
+
+func FormatMessengerTextWithHeader(header, body string) string {
+	return header + "\n\n" + body
+}

--- a/pkg/alert/formatter_test.go
+++ b/pkg/alert/formatter_test.go
@@ -103,3 +103,28 @@ func TestFormatMessengerText(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatMessengerTextWithHeader(t *testing.T) {
+	tests := []struct {
+		name         string
+		header       string
+		body         string
+		expectedText string
+	}{
+		{
+			name:         "Header with body formatted with 2 newlines",
+			header:       "Test Header",
+			body:         "Test Body",
+			expectedText: "Test Header\n\nTest Body",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualText := FormatMessengerTextWithHeader(tt.header, tt.body)
+			if actualText != tt.expectedText {
+				t.Errorf("expected %s, got %s", tt.expectedText, actualText)
+			}
+		})
+	}
+}

--- a/pkg/alert/notifier.go
+++ b/pkg/alert/notifier.go
@@ -2,6 +2,7 @@ package alert
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -84,6 +85,15 @@ func NewNotifier(httpClient HTTPClient, config *config.Config, logger logger.Log
 		} else {
 			payloadSenders = append(payloadSenders, pgwSender)
 		}
+	}
+
+	// Discord
+	fmt.Println(config)
+	fmt.Println("DIscord channel ID:", config.DiscordChannelID)
+	fmt.Println("Token ID: ", config.DiscordBotToken)
+	if config.DiscordChannelID != "" && config.DiscordBotToken != "" {
+		fmt.Println("here")
+		notificationSenders = append(notificationSenders, NewDiscordSender(httpClient, config, logger))
 	}
 
 	return &notifier{

--- a/pkg/alert/notifier.go
+++ b/pkg/alert/notifier.go
@@ -2,7 +2,6 @@ package alert
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -88,11 +87,7 @@ func NewNotifier(httpClient HTTPClient, config *config.Config, logger logger.Log
 	}
 
 	// Discord
-	fmt.Println(config)
-	fmt.Println("DIscord channel ID:", config.DiscordChannelID)
-	fmt.Println("Token ID: ", config.DiscordBotToken)
 	if config.DiscordChannelID != "" && config.DiscordBotToken != "" {
-		fmt.Println("here")
 		notificationSenders = append(notificationSenders, NewDiscordSender(httpClient, config, logger))
 	}
 

--- a/pkg/alert/notifier.go
+++ b/pkg/alert/notifier.go
@@ -88,7 +88,12 @@ func NewNotifier(httpClient HTTPClient, config *config.Config, logger logger.Log
 
 	// Discord
 	if config.DiscordChannelID != "" && config.DiscordBotToken != "" {
-		notificationSenders = append(notificationSenders, NewDiscordSender(httpClient, config, logger))
+		discordSender, err := NewDiscordSender(httpClient, config, logger)
+		if err != nil {
+			logger.Error("error creating new Discord sender:", err)
+		} else {
+			notificationSenders = append(notificationSenders, discordSender)
+		}
 	}
 
 	return &notifier{

--- a/pkg/alert/notifier_test.go
+++ b/pkg/alert/notifier_test.go
@@ -51,7 +51,7 @@ func TestNewNotifier(t *testing.T) {
 
 	notifierTelegram := NewNotifier(&successStatushTTPClient, configDefault, mockLogger)
 	if notifierTelegram == nil {
-		t.Error("unexpected nil on output (Telegram*)")
+		t.Fatal("unexpected nil on output (Telegram*)")
 	}
 
 	if notifiersLen := len(notifierTelegram.chatNotifiers); notifiersLen == 0 {
@@ -64,7 +64,7 @@ func TestNewNotifier(t *testing.T) {
 
 	notifierAPI := NewNotifier(&successStatushTTPClient, configDefault, mockLogger)
 	if notifierAPI == nil {
-		t.Error("unexpected nil on output (ApiURL)")
+		t.Fatal("unexpected nil on output (ApiURL)")
 	}
 
 	if len(notifierAPI.machineNotifiers) != 1 {
@@ -75,7 +75,7 @@ func TestNewNotifier(t *testing.T) {
 
 	notifierAPI = NewNotifier(&successStatushTTPClient, configDefault, mockLogger)
 	if notifierAPI == nil {
-		t.Error("unexpected nil on output (ApiURL)")
+		t.Fatal("unexpected nil on output (ApiURL)")
 	}
 
 	if len(notifierAPI.machineNotifiers) != 0 {
@@ -88,7 +88,7 @@ func TestNewNotifier(t *testing.T) {
 
 	notifierWebhook := NewNotifier(&successStatushTTPClient, configDefault, mockLogger)
 	if notifierWebhook == nil {
-		t.Error("unexpected nil on output (Webhooks)")
+		t.Fatal("unexpected nil on output (Webhooks)")
 	}
 
 	if len(notifierWebhook.machineNotifiers) != 1 {
@@ -99,7 +99,7 @@ func TestNewNotifier(t *testing.T) {
 
 	notifierWebhook = NewNotifier(&successStatushTTPClient, configDefault, mockLogger)
 	if notifierWebhook == nil {
-		t.Error("unexpected nil on output (Webhooks)")
+		t.Fatal("unexpected nil on output (Webhooks)")
 	}
 
 	if len(notifierWebhook.machineNotifiers) != 0 {
@@ -112,7 +112,7 @@ func TestNewNotifier(t *testing.T) {
 
 	notifierPushgateway := NewNotifier(&successStatushTTPClient, configDefault, mockLogger)
 	if notifierPushgateway == nil {
-		t.Error("unexpected nil on output (Pushgateway)")
+		t.Fatal("unexpected nil on output (Pushgateway)")
 	}
 
 	if len(notifierPushgateway.machineNotifiers) != 1 {
@@ -123,7 +123,7 @@ func TestNewNotifier(t *testing.T) {
 
 	notifierPushgateway = NewNotifier(&successStatushTTPClient, configDefault, mockLogger)
 	if notifierPushgateway == nil {
-		t.Error("unexpected nil on output (Pushgateway)")
+		t.Fatal("unexpected nil on output (Pushgateway)")
 	}
 
 	if len(notifierPushgateway.machineNotifiers) != 0 {
@@ -154,7 +154,7 @@ func TestSendChatNotifications(t *testing.T) {
 
 	notifierTelegram = NewNotifier(&successStatushTTPClient, configDefault, mockLogger)
 	if notifierTelegram == nil {
-		t.Error("unexpected nil on output")
+		t.Fatal("unexpected nil on output")
 	}
 
 	if err := notifierTelegram.SendChatNotifications("SendChatNotifications test", 0); err != nil {
@@ -190,7 +190,7 @@ func TestSendMachineNotifications(t *testing.T) {
 
 	notifierWebhook = NewNotifier(nil, configDefault, mockLogger)
 	if notifierWebhook == nil {
-		t.Error("unexpected nil on output (Webhooks)")
+		t.Fatal("unexpected nil on output (Webhooks)")
 	}
 
 	if err := notifierWebhook.SendMachineNotifications(nil, 0); err != nil {

--- a/pkg/alert/notifier_test.go
+++ b/pkg/alert/notifier_test.go
@@ -51,6 +51,7 @@ func TestNewNotifier_Telegram(t *testing.T) {
 		successStatusHTTPClient = SuccessStatusHTTPClient{}
 	)
 
+	configDefault, _ = config.NewConfig(flag.CommandLine, []string{""})
 	configDefault.TelegramBotToken = "abc:2025062700"
 	configDefault.TelegramChatID = "-10987654321"
 
@@ -70,6 +71,7 @@ func TestNewNotifier_API(t *testing.T) {
 		successStatusHTTPClient = SuccessStatusHTTPClient{}
 	)
 
+	configDefault, _ = config.NewConfig(flag.CommandLine, []string{""})
 	configDefault.ApiURL = "https://api.example.com/?test=true"
 
 	notifierAPI := NewNotifier(&successStatusHTTPClient, configDefault, mockLogger)
@@ -99,6 +101,7 @@ func TestNewNotifier_Webhook(t *testing.T) {
 		successStatusHTTPClient = SuccessStatusHTTPClient{}
 	)
 
+	configDefault, _ = config.NewConfig(flag.CommandLine, []string{""})
 	configDefault.WebhookURL = "https://www.example.com/hooks/test-hook"
 
 	notifierWebhook := NewNotifier(&successStatusHTTPClient, configDefault, mockLogger)
@@ -128,6 +131,7 @@ func TestNewNotifier_Pushgateawy(t *testing.T) {
 		successStatusHTTPClient = SuccessStatusHTTPClient{}
 	)
 
+	configDefault, _ = config.NewConfig(flag.CommandLine, []string{""})
 	configDefault.PushgatewayURL = "https://pgw.example.com/push/"
 
 	notifierPushgateway := NewNotifier(&successStatusHTTPClient, configDefault, mockLogger)
@@ -157,6 +161,7 @@ func TestNewNotifier_Discord(t *testing.T) {
 		successStatusHTTPClient = SuccessStatusHTTPClient{}
 	)
 
+	configDefault, _ = config.NewConfig(flag.CommandLine, []string{""})
 	configDefault.DiscordBotToken = "test"
 	configDefault.DiscordChannelID = "-123"
 
@@ -176,6 +181,7 @@ func TestSendChatNotifications(t *testing.T) {
 		successStatusHTTPClient = SuccessStatusHTTPClient{}
 	)
 
+	configDefault, _ = config.NewConfig(flag.CommandLine, []string{""})
 	configDefault.TelegramBotToken = ""
 	configDefault.TelegramChatID = ""
 
@@ -213,7 +219,7 @@ func TestSendMachineNotifications(t *testing.T) {
 		mockLogger              = &MockLogger{}
 		successStatusHTTPClient = SuccessStatusHTTPClient{}
 	)
-
+	configDefault, _ = config.NewConfig(flag.CommandLine, []string{""})
 	configDefault.WebhookURL = ""
 
 	notifierWebhook := NewNotifier(&successStatusHTTPClient, configDefault, mockLogger)

--- a/pkg/alert/notifier_test.go
+++ b/pkg/alert/notifier_test.go
@@ -2,6 +2,7 @@ package alert
 
 import (
 	"flag"
+	"fmt"
 	"testing"
 
 	"go.vxn.dev/dish/pkg/config"
@@ -11,10 +12,6 @@ const (
 	badURL = "0řžuničx://č/tmpě/test.hook\x09"
 )
 
-var (
-	configDefault *config.Config
-)
-
 func TestNewNotifier_Nil(t *testing.T) {
 	var (
 		configBlank             = &config.Config{}
@@ -22,7 +19,7 @@ func TestNewNotifier_Nil(t *testing.T) {
 		successStatusHTTPClient = SuccessStatusHTTPClient{}
 	)
 
-	configDefault, _ = config.NewConfig(flag.CommandLine, []string{""})
+	configDefault, _ := config.NewConfig(flag.NewFlagSet("test", flag.ContinueOnError), []string{""})
 
 	if notifier := NewNotifier(nil, nil, nil); notifier != nil {
 		t.Error("unexpected behaviour, should be nil")
@@ -51,7 +48,7 @@ func TestNewNotifier_Telegram(t *testing.T) {
 		successStatusHTTPClient = SuccessStatusHTTPClient{}
 	)
 
-	configDefault, _ = config.NewConfig(flag.CommandLine, []string{""})
+	configDefault, _ := config.NewConfig(flag.NewFlagSet("test", flag.ContinueOnError), []string{""})
 	configDefault.TelegramBotToken = "abc:2025062700"
 	configDefault.TelegramChatID = "-10987654321"
 
@@ -71,7 +68,7 @@ func TestNewNotifier_API(t *testing.T) {
 		successStatusHTTPClient = SuccessStatusHTTPClient{}
 	)
 
-	configDefault, _ = config.NewConfig(flag.CommandLine, []string{""})
+	configDefault, _ := config.NewConfig(flag.NewFlagSet("test", flag.ContinueOnError), []string{""})
 	configDefault.ApiURL = "https://api.example.com/?test=true"
 
 	notifierAPI := NewNotifier(&successStatusHTTPClient, configDefault, mockLogger)
@@ -101,7 +98,7 @@ func TestNewNotifier_Webhook(t *testing.T) {
 		successStatusHTTPClient = SuccessStatusHTTPClient{}
 	)
 
-	configDefault, _ = config.NewConfig(flag.CommandLine, []string{""})
+	configDefault, _ := config.NewConfig(flag.NewFlagSet("test", flag.ContinueOnError), []string{""})
 	configDefault.WebhookURL = "https://www.example.com/hooks/test-hook"
 
 	notifierWebhook := NewNotifier(&successStatusHTTPClient, configDefault, mockLogger)
@@ -131,7 +128,7 @@ func TestNewNotifier_Pushgateawy(t *testing.T) {
 		successStatusHTTPClient = SuccessStatusHTTPClient{}
 	)
 
-	configDefault, _ = config.NewConfig(flag.CommandLine, []string{""})
+	configDefault, _ := config.NewConfig(flag.NewFlagSet("test", flag.ContinueOnError), []string{""})
 	configDefault.PushgatewayURL = "https://pgw.example.com/push/"
 
 	notifierPushgateway := NewNotifier(&successStatusHTTPClient, configDefault, mockLogger)
@@ -161,7 +158,7 @@ func TestNewNotifier_Discord(t *testing.T) {
 		successStatusHTTPClient = SuccessStatusHTTPClient{}
 	)
 
-	configDefault, _ = config.NewConfig(flag.CommandLine, []string{""})
+	configDefault, _ := config.NewConfig(flag.NewFlagSet("test", flag.ContinueOnError), []string{""})
 	configDefault.DiscordBotToken = "test"
 	configDefault.DiscordChannelID = "-123"
 
@@ -181,11 +178,12 @@ func TestSendChatNotifications(t *testing.T) {
 		successStatusHTTPClient = SuccessStatusHTTPClient{}
 	)
 
-	configDefault, _ = config.NewConfig(flag.CommandLine, []string{""})
+	configDefault, _ := config.NewConfig(flag.NewFlagSet("test", flag.ContinueOnError), []string{""})
 	configDefault.TelegramBotToken = ""
 	configDefault.TelegramChatID = ""
 
 	notifierTelegram := NewNotifier(&successStatusHTTPClient, configDefault, mockLogger)
+	fmt.Println(notifierTelegram.chatNotifiers)
 	if len(notifierTelegram.chatNotifiers) > 0 {
 		t.Errorf("expected 0 chatNotifiers, got %d", len(notifierTelegram.chatNotifiers))
 	}
@@ -219,7 +217,7 @@ func TestSendMachineNotifications(t *testing.T) {
 		mockLogger              = &MockLogger{}
 		successStatusHTTPClient = SuccessStatusHTTPClient{}
 	)
-	configDefault, _ = config.NewConfig(flag.CommandLine, []string{""})
+	configDefault, _ := config.NewConfig(flag.NewFlagSet("test", flag.ContinueOnError), []string{""})
 	configDefault.WebhookURL = ""
 
 	notifierWebhook := NewNotifier(&successStatusHTTPClient, configDefault, mockLogger)

--- a/pkg/alert/notifier_test.go
+++ b/pkg/alert/notifier_test.go
@@ -151,6 +151,25 @@ func TestNewNotifier_Pushgateawy(t *testing.T) {
 	}
 }
 
+func TestNewNotifier_Discord(t *testing.T) {
+	var (
+		mockLogger              = &MockLogger{}
+		successStatusHTTPClient = SuccessStatusHTTPClient{}
+	)
+
+	configDefault.DiscordBotToken = "test"
+	configDefault.DiscordChannelID = "-123"
+
+	notifierDiscord := NewNotifier(&successStatusHTTPClient, configDefault, mockLogger)
+	if notifierDiscord == nil {
+		t.Fatal("unexpected nil on output (Discord*)")
+	}
+
+	if notifiersLen := len(notifierDiscord.chatNotifiers); notifiersLen == 0 {
+		t.Errorf("expected 1 chatNotifier: got %d", notifiersLen)
+	}
+}
+
 func TestSendChatNotifications(t *testing.T) {
 	var (
 		mockLogger              = &MockLogger{}

--- a/pkg/alert/telegram.go
+++ b/pkg/alert/telegram.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	baseURL      = "https://api.telegram.org"
-	messageTitle = "\U0001F4E1 <b>dish run results</b>:" // 📡
+	baseURL              = "https://api.telegram.org"
+	telegramMessageTitle = "\U0001F4E1 <b>dish run results</b>:" // 📡
 )
 
 type telegramSender struct {
@@ -49,7 +49,7 @@ func (s *telegramSender) send(rawMessage string, failedCount int) error {
 	params.Set("chat_id", s.chatID)
 	params.Set("disable_web_page_preview", "true")
 	params.Set("parse_mode", "HTML")
-	params.Set("text", messageTitle+"\n\n"+rawMessage)
+	params.Set("text", FormatMessengerTextWithHeader(telegramMessageTitle, rawMessage))
 
 	fullURL := telegramURL + "?" + params.Encode()
 

--- a/pkg/alert/transport.go
+++ b/pkg/alert/transport.go
@@ -49,7 +49,7 @@ func handleSubmit(client HTTPClient, method string, url string, body io.Reader, 
 		opt(&options)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
@@ -68,7 +68,6 @@ func handleSubmit(client HTTPClient, method string, url string, body io.Reader, 
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
 
 	return res, nil
 }

--- a/pkg/alert/transport.go
+++ b/pkg/alert/transport.go
@@ -1,9 +1,11 @@
 package alert
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"go.vxn.dev/dish/pkg/logger"
 )
@@ -47,7 +49,10 @@ func handleSubmit(client HTTPClient, method string, url string, body io.Reader, 
 		opt(&options)
 	}
 
-	req, err := http.NewRequest(method, url, body)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
 	}
@@ -63,6 +68,7 @@ func handleSubmit(client HTTPClient, method string, url string, body io.Reader, 
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 
 	return res, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,8 +87,8 @@ func defineFlags(fs *flag.FlagSet, cfg *Config) {
 	fs.StringVar(&cfg.WebhookURL, "webhookURL", defaultWebhookURL, "a string, URL of webhook endpoint")
 
 	// Discord:
-	//fs.StringVar(&cfg.DiscordBotToken, "discordBotToken", defaultDiscordBotToken, "a string, Discord bot token")
-	//fs.StringVar(&cfg.DiscordChannelID, "discordChannelId", defaultDiscordChannelID, "a string, Discord channel ID")
+	fs.StringVar(&cfg.DiscordBotToken, "discordBotToken", defaultDiscordBotToken, "a string, Discord bot token")
+	fs.StringVar(&cfg.DiscordChannelID, "discordChannelId", defaultDiscordChannelID, "a string, Discord channel ID")
 }
 
 // NewConfig returns a new instance of Config.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,8 @@ type Config struct {
 	WebhookURL           string
 	TextNotifySuccess    bool
 	MachineNotifySuccess bool
+	DiscordBotToken      string
+	DiscordChannelID     string
 }
 
 const (
@@ -44,6 +46,8 @@ const (
 	defaultWebhookURL           = ""
 	defaultTextNotifySuccess    = false
 	defaultMachineNotifySuccess = false
+	defaultDiscordBotToken      = ""
+	defaultDiscordChannelID     = ""
 )
 
 // ErrNoSourceProvided is returned when no source of sockets is specified.
@@ -81,6 +85,10 @@ func defineFlags(fs *flag.FlagSet, cfg *Config) {
 
 	// Webhooks:
 	fs.StringVar(&cfg.WebhookURL, "webhookURL", defaultWebhookURL, "a string, URL of webhook endpoint")
+
+	// Discord:
+	//fs.StringVar(&cfg.DiscordBotToken, "discordBotToken", defaultDiscordBotToken, "a string, Discord bot token")
+	//fs.StringVar(&cfg.DiscordChannelID, "discordChannelId", defaultDiscordChannelID, "a string, Discord channel ID")
 }
 
 // NewConfig returns a new instance of Config.
@@ -106,6 +114,8 @@ func NewConfig(fs *flag.FlagSet, args []string) (*Config, error) {
 		TimeoutSeconds:     defaultTimeoutSeconds,
 		ApiURL:             defaultApiURL,
 		WebhookURL:         defaultWebhookURL,
+		DiscordBotToken:    defaultDiscordBotToken,
+		DiscordChannelID:   defaultDiscordChannelID,
 	}
 
 	defineFlags(fs, cfg)


### PR DESCRIPTION
This PR is an attempt to implement the Issue #38. 

## Changes

- Implemented discord sender
- Added a timeout context for the requests
- Use a separate flag set for each notifier test to avoid conflicts

## Example
<img width="1282" alt="Screenshot 2025-07-06 at 16 31 53" src="https://github.com/user-attachments/assets/bec1dbd2-7623-4056-ab58-b3902b3f8ced" />

---
- [x] I have run the linter (`golangci-lint run`) and fixed any issues.
- [ ] I have run all existing tests and they pass. // The icmp test for localhost fails on my machine
- [x] I have added meaningful, concise commit messages, written in an imperative style ("Add files", "Fix logger", etc.).


Make sure to check the boxes below if they are applicable to the given situation (of course, it is not necessary to write tests when updating README etc.):

- [x] My PR includes tests, covering at least the bare minimum functionality.
- [x] I have updated documentation (README).
- [x] I have linked related issues.
